### PR TITLE
ci: add pull-request permission in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 
 env:
   NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
Added `pull-requests:write` to allow Changesets to create PRs