### PR TITLE
fix(deno): include standard TS libs and use explicit .ts extension on imports

### DIFF
--- a/.changeset/blue-pugs-take.md
+++ b/.changeset/blue-pugs-take.md
@@ -1,0 +1,9 @@
+---
+'@yoot/cloudinary': minor
+'@yoot/shopify': minor
+'@yoot/sanity': minor
+'@yoot/imgix': minor
+'@yoot/yoot': minor
+---
+
+Enabled `allowImportingTsExtensions: true` in `tsconfig.base.json` and updated all relevant imports in the packages directory to ensure consistent compatibility across environments.

--- a/.changeset/eager-pandas-tickle.md
+++ b/.changeset/eager-pandas-tickle.md
@@ -1,0 +1,9 @@
+---
+'@yoot/cloudinary': minor
+'@yoot/shopify': minor
+'@yoot/sanity': minor
+'@yoot/imgix': minor
+'@yoot/yoot': minor
+---
+
+Added `deno.ns`, `dom`, and `esnext` to `compilerOptions.lib` in `deno.json` for all packages to fix Deno type errors and ensure compatibility.

--- a/packages/adapters/cloudinary/deno.json
+++ b/packages/adapters/cloudinary/deno.json
@@ -5,6 +5,9 @@
     ".": "./src/index.ts",
     "./register": "./src/register.ts"
   },
+  "compilerOptions": {
+    "lib": ["deno.ns", "dom", "esnext"]
+  },
   "publish": {
     "include": ["src", "deno.json", "LICENSE", "README.md"],
     "exclude": ["src/api-extractor.ts"]

--- a/packages/adapters/cloudinary/src/api-extractor.ts
+++ b/packages/adapters/cloudinary/src/api-extractor.ts
@@ -2,6 +2,6 @@
  * Official Cloudinary adapter package.
  * @packageDocumentation
  */
-export * from './index';
+export * from './index.ts';
 
-export * as register from './register';
+export * as register from './register.ts';

--- a/packages/adapters/cloudinary/src/index.ts
+++ b/packages/adapters/cloudinary/src/index.ts
@@ -1,1 +1,1 @@
-export {adapter as cloudinaryAdapter, adapter as default} from './core/adapter';
+export {adapter as cloudinaryAdapter, adapter as default} from './core/adapter.ts';

--- a/packages/adapters/cloudinary/src/register.ts
+++ b/packages/adapters/cloudinary/src/register.ts
@@ -1,5 +1,5 @@
 import {registerAdapters} from '@yoot/yoot';
-import {adapter} from './core/adapter';
+import {adapter} from './core/adapter.ts';
 /**
  * Automatic adapter registration for the Cloudinary adapter.
  * @packageDocumentation

--- a/packages/adapters/imgix/deno.json
+++ b/packages/adapters/imgix/deno.json
@@ -5,6 +5,9 @@
     ".": "./src/index.ts",
     "./register": "./src/register.ts"
   },
+  "compilerOptions": {
+    "lib": ["deno.ns", "dom", "esnext"]
+  },
   "publish": {
     "include": ["src", "deno.json", "LICENSE", "README.md"],
     "exclude": ["src/api-extractor.ts"]

--- a/packages/adapters/imgix/src/api-extractor.ts
+++ b/packages/adapters/imgix/src/api-extractor.ts
@@ -2,6 +2,6 @@
  * Official Imgix adapter package.
  * @packageDocumentation
  */
-export * from './index';
+export * from './index.ts';
 
-export * as register from './register';
+export * as register from './register.ts';

--- a/packages/adapters/imgix/src/index.ts
+++ b/packages/adapters/imgix/src/index.ts
@@ -1,1 +1,1 @@
-export {adapter as imgixAdapter, adapter as default} from './core/adapter';
+export {adapter as imgixAdapter, adapter as default} from './core/adapter.ts';

--- a/packages/adapters/imgix/src/register.ts
+++ b/packages/adapters/imgix/src/register.ts
@@ -1,5 +1,5 @@
 import {registerAdapters} from '@yoot/yoot';
-import {adapter} from './core/adapter';
+import {adapter} from './core/adapter.ts';
 
 export {};
 

--- a/packages/adapters/sanity/deno.json
+++ b/packages/adapters/sanity/deno.json
@@ -5,6 +5,9 @@
     ".": "./src/index.ts",
     "./register": "./src/register.ts"
   },
+  "compilerOptions": {
+    "lib": ["deno.ns", "dom", "esnext"]
+  },
   "publish": {
     "include": ["src", "deno.json", "LICENSE", "README.md"],
     "exclude": ["src/api-extractor.ts"]

--- a/packages/adapters/sanity/src/api-extractor.ts
+++ b/packages/adapters/sanity/src/api-extractor.ts
@@ -2,6 +2,6 @@
  * Official Sanity adapter package.
  * @packageDocumentation
  */
-export * from './index';
+export * from './index.ts';
 
-export * as register from './register';
+export * as register from './register.ts';

--- a/packages/adapters/sanity/src/index.ts
+++ b/packages/adapters/sanity/src/index.ts
@@ -1,1 +1,1 @@
-export {adapter as sanityAdapter, adapter as default} from './core/adapter';
+export {adapter as sanityAdapter, adapter as default} from './core/adapter.ts';

--- a/packages/adapters/sanity/src/register.ts
+++ b/packages/adapters/sanity/src/register.ts
@@ -1,5 +1,5 @@
 import {registerAdapters} from '@yoot/yoot';
-import {adapter} from './core/adapter';
+import {adapter} from './core/adapter.ts';
 
 export {};
 

--- a/packages/adapters/shopify/deno.json
+++ b/packages/adapters/shopify/deno.json
@@ -5,6 +5,9 @@
     ".": "./src/index.ts",
     "./register": "./src/register.ts"
   },
+  "compilerOptions": {
+    "lib": ["deno.ns", "dom", "esnext"]
+  },
   "publish": {
     "include": ["src", "deno.json", "LICENSE", "README.md"],
     "exclude": ["src/api-extractor.ts"]

--- a/packages/adapters/shopify/src/api-extractor.ts
+++ b/packages/adapters/shopify/src/api-extractor.ts
@@ -2,6 +2,6 @@
  * Official Shopify adapter package.
  * @packageDocumentation
  */
-export * from './index';
+export * from './index.ts';
 
-export * as register from './register';
+export * as register from './register.ts';

--- a/packages/adapters/shopify/src/index.ts
+++ b/packages/adapters/shopify/src/index.ts
@@ -1,1 +1,1 @@
-export {adapter as shopifyAdapter, adapter as default} from './core/adapter';
+export {adapter as shopifyAdapter, adapter as default} from './core/adapter.ts';

--- a/packages/adapters/shopify/src/register.ts
+++ b/packages/adapters/shopify/src/register.ts
@@ -1,5 +1,5 @@
 import {registerAdapters} from '@yoot/yoot';
-import {adapter} from './core/adapter';
+import {adapter} from './core/adapter.ts';
 
 export {};
 

--- a/packages/yoot/deno.json
+++ b/packages/yoot/deno.json
@@ -7,6 +7,9 @@
     "./internal": "./src/internal.ts",
     "./jsx": "./src/jsx.ts"
   },
+  "compilerOptions": {
+    "lib": ["deno.ns", "dom", "esnext"]
+  },
   "publish": {
     "include": ["src", "deno.json", "LICENSE", "README.md"],
     "exclude": ["src/api-extractor.ts"]

--- a/packages/yoot/src/api-extractor.ts
+++ b/packages/yoot/src/api-extractor.ts
@@ -2,23 +2,23 @@
  * Core `yoot` API.
  * @packageDocumentation
  */
-export * from './index'; // Assumes './index.ts' exports the curated public core API
+export * from './index.ts';
 
 /**
  * JSX utilities for `yoot` (React, SolidJS, etc.).
  * @packageDocumentation
  */
-export * as jsx from './jsx';
+export * as jsx from './jsx.ts';
 
 /**
  * HTML utilities for `yoot` (Astro, Svelte, etc.).
  * @packageDocumentation
  */
-export * as html from './html';
+export * as html from './html.ts';
 
 /**
  * INTERNAL USE ONLY. For `yoot` adapters. Not for public use.
  * @packageDocumentation
  * @internal
  */
-export * as internal from './internal';
+export * as internal from './internal.ts';

--- a/packages/yoot/src/core/adapter.ts
+++ b/packages/yoot/src/core/adapter.ts
@@ -1,7 +1,7 @@
-import type {Directives, YootState, PrimeStateInput} from './yoot';
-import {_getConfig as getConfig} from './config';
-import {adapterStore} from './store';
-import {invariant} from './utils';
+import type {Directives, YootState, PrimeStateInput} from './yoot.ts';
+import {_getConfig as getConfig} from './config.ts';
+import {adapterStore} from './store.ts';
+import {invariant} from './utils.ts';
 
 // --- Module Exports ---
 export {createAdapter, passThroughAdapter, registerAdapters};

--- a/packages/yoot/src/core/config.ts
+++ b/packages/yoot/src/core/config.ts
@@ -1,4 +1,4 @@
-import type {Adapter} from './adapter';
+import type {Adapter} from './adapter.ts';
 
 // -- Module Exports --
 export {defineConfig, mergeConfig};

--- a/packages/yoot/src/core/helpers.ts
+++ b/packages/yoot/src/core/helpers.ts
@@ -1,7 +1,7 @@
-import type {GenerateUrlInput} from './adapter';
-import type {Directives, Yoot, YootState} from './yoot';
-import type {HTMLImageAttributes, HTMLSourceAttributes, Maybe, Prettify} from './types';
-import {isKeyOf, isFunction, hasIntrinsicDimensions, invariant, isNumber, isString, isNullish} from './utils';
+import type {GenerateUrlInput} from './adapter.ts';
+import type {Directives, Yoot, YootState} from './yoot.ts';
+import type {HTMLImageAttributes, HTMLSourceAttributes, Maybe, Prettify} from './types.ts';
+import {isKeyOf, isFunction, hasIntrinsicDimensions, invariant, isNumber, isString, isNullish} from './utils.ts';
 
 export {
   buildSrcSet,

--- a/packages/yoot/src/core/html.ts
+++ b/packages/yoot/src/core/html.ts
@@ -1,4 +1,4 @@
-import {getImgAttrs as _getImgAttrs, getSourceAttrs as _getSourceAttrs} from './helpers';
+import {getImgAttrs as _getImgAttrs, getSourceAttrs as _getSourceAttrs} from './helpers.ts';
 import type {
   BuildSrcSetOptions,
   ImgAttrs as _ImgAttrs,
@@ -6,12 +6,12 @@ import type {
   SourceAttrs as _SourceAttrs,
   SourceAttrsOptions,
   WithSrcSetBuilder,
-} from './helpers';
-import type {Yoot} from './yoot';
-import {isEmpty, isNullish} from './utils';
+} from './helpers.ts';
+import type {Yoot} from './yoot.ts';
+import {isEmpty, isNullish} from './utils.ts';
 
 // -- Module Exports --
-export {buildSrcSet, defineSrcSetBuilder} from './helpers';
+export {buildSrcSet, defineSrcSetBuilder} from './helpers.ts';
 export {getImgAttrs, getSourceAttrs, withImgAttrs, withSourceAttrs};
 export type {BuildSrcSetOptions, ImgAttrs, ImgAttrsOptions, SourceAttrs, SourceAttrsOptions, WithSrcSetBuilder};
 // For testing purposes

--- a/packages/yoot/src/core/store.ts
+++ b/packages/yoot/src/core/store.ts
@@ -1,4 +1,4 @@
-import type {Adapter} from './adapter';
+import type {Adapter} from './adapter.ts';
 
 // -- Module Exports --
 export {adapterStore, YOOT_BRAND};

--- a/packages/yoot/src/core/yoot.ts
+++ b/packages/yoot/src/core/yoot.ts
@@ -1,7 +1,7 @@
-import {_getAdapter as getAdapter} from './adapter';
-import {mustBeOneOf, mustBeInRange, normalizeDirectives} from './helpers';
-import {YOOT_BRAND} from './store';
-import {invariant, isNullish, isNumber, isString} from './utils';
+import {_getAdapter as getAdapter} from './adapter.ts';
+import {mustBeOneOf, mustBeInRange, normalizeDirectives} from './helpers.ts';
+import {YOOT_BRAND} from './store.ts';
+import {invariant, isNullish, isNumber, isString} from './utils.ts';
 
 // -- Module Exports --
 // API function and helpers

--- a/packages/yoot/src/html.ts
+++ b/packages/yoot/src/html.ts
@@ -1,1 +1,1 @@
-export * from './core/html';
+export * from './core/html.ts';

--- a/packages/yoot/src/index.ts
+++ b/packages/yoot/src/index.ts
@@ -1,8 +1,8 @@
-export {yoot} from './core/yoot';
-export type * from './core/yoot';
+export {yoot} from './core/yoot.ts';
+export type * from './core/yoot.ts';
 
-export {createAdapter, passThroughAdapter, registerAdapters} from './core/adapter';
-export type * from './core/adapter';
+export {createAdapter, passThroughAdapter, registerAdapters} from './core/adapter.ts';
+export type * from './core/adapter.ts';
 
-export {defineConfig, mergeConfig, type YootConfig} from './core/config';
-export {hasIntrinsicDimensions} from './core/utils';
+export {defineConfig, mergeConfig, type YootConfig} from './core/config.ts';
+export {hasIntrinsicDimensions} from './core/utils.ts';

--- a/packages/yoot/src/internal.ts
+++ b/packages/yoot/src/internal.ts
@@ -10,4 +10,4 @@ export {
   isNullish as _isNullish,
   isNumber as _isNumber,
   isString as _isString,
-} from './core/utils';
+} from './core/utils.ts';

--- a/packages/yoot/src/jsx.ts
+++ b/packages/yoot/src/jsx.ts
@@ -5,5 +5,5 @@ export {
   getSourceAttrs,
   withImgAttrs,
   withSourceAttrs,
-} from './core/helpers';
-export type * from './core/helpers';
+} from './core/helpers.ts';
+export type * from './core/helpers.ts';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,7 @@
     "moduleDetection": "force",
     // Bundler behavior
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,
     // Safety & strictness


### PR DESCRIPTION
This PR fixes Deno compatibility and enable explicit `.ts` imports across packages.

- Enabled `allowImportingTsExtensions: true` in `tsconfig.base.json` and updated all relevant imports in the packages directory to ensure consistent compatibility across environments.
- Added `deno.ns`, `dom`, and `esnext` to `compilerOptions.lib` in `deno.json` for all packages to fix Deno type errors and ensure compatibility.