### PR TITLE
test: add smoke tests and unify multi-runtime test scripts

### DIFF
--- a/.changeset/blue-pugs-take.md
+++ b/.changeset/blue-pugs-take.md
@@ -1,0 +1,9 @@
+---
+'@yoot/cloudinary': minor
+'@yoot/shopify': minor
+'@yoot/sanity': minor
+'@yoot/imgix': minor
+'@yoot/yoot': minor
+---
+
+Enabled `allowImportingTsExtensions: true` in `tsconfig.base.json` and updated all relevant imports in the packages directory to ensure consistent compatibility across environments.

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist/
 # API Extractor/Documenter
 temp/
 
+# Lock files
+deno.lock
+
 # Logs
 pnpm-debug.log*
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules/
 
 # Build output and cache
+.wrangler/
 coverage/
 dist/
 *.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "version": "pnpm changeset version && node ./scripts/sync-jsr-versions.js",
     "release": "pnpm build:lib && pnpm changeset publish && pnpm jsr publish",
     "test": "vitest run",
+    "test:bun": "pnpm --parallel -r test:bun",
     "test:deno": "pnpm --parallel -r test:deno",
     "test:coverage": "vitest run --coverage"
   },
@@ -23,6 +24,7 @@
     "@microsoft/api-documenter": "^7.26.27",
     "@microsoft/api-extractor": "^7.52.8",
     "@vitest/coverage-v8": "^3.1.4",
+    "bun": "^1.2.15",
     "deno": "^2.3.5",
     "eslint": "^9.27.0",
     "fast-glob": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "release": "pnpm build:lib && pnpm changeset publish && pnpm jsr publish",
     "test": "vitest run",
     "test:bun": "pnpm --parallel -r test:bun",
+    "test:cloudflare": "pnpm -r --parallel --workspace-concurrency=1 test:cloudflare",
     "test:deno": "pnpm --parallel -r test:deno",
     "test:coverage": "vitest run --coverage"
   },
@@ -34,7 +35,8 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.33.0",
     "vite": "^6.3.5",
-    "vitest": "^3.1.4"
+    "vitest": "^3.1.4",
+    "wrangler": "^4.18.0"
   },
   "packageManager": "pnpm@10.11.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "version": "pnpm changeset version && node ./scripts/sync-jsr-versions.js",
     "release": "pnpm build:lib && pnpm changeset publish && pnpm jsr publish",
     "test": "vitest run",
+    "test:deno": "pnpm --parallel -r test:deno",
     "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
@@ -22,6 +23,7 @@
     "@microsoft/api-documenter": "^7.26.27",
     "@microsoft/api-extractor": "^7.52.8",
     "@vitest/coverage-v8": "^3.1.4",
+    "deno": "^2.3.5",
     "eslint": "^9.27.0",
     "fast-glob": "^3.3.3",
     "globals": "^16.2.0",

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "lint": "npx eslint .",
     "version": "pnpm changeset version && node ./scripts/sync-jsr-versions.js",
     "release": "pnpm build:lib && pnpm changeset publish && pnpm jsr publish",
-    "test": "vitest run",
+    "test": "pnpm -r --parallel --workspace-concurrency=1 test",
     "test:bun": "pnpm --parallel -r test:bun",
     "test:cloudflare": "pnpm -r --parallel --workspace-concurrency=1 test:cloudflare",
+    "test:coverage": "vitest run --coverage",
     "test:deno": "pnpm --parallel -r test:deno",
-    "test:coverage": "vitest run --coverage"
+    "test:node": "vitest run"
   },
   "devDependencies": {
     "@changesets/changelog-git": "^0.2.1",

--- a/packages/adapters/cloudinary/deno.test.json
+++ b/packages/adapters/cloudinary/deno.test.json
@@ -1,0 +1,9 @@
+{
+  "imports": {
+    "@yoot/yoot/internal": "../../yoot/src/internal.ts",
+    "@yoot/yoot": "../../yoot/src/index.ts"
+  },
+  "compilerOptions": {
+    "lib": ["deno.ns", "dom", "esnext"]
+  }
+}

--- a/packages/adapters/cloudinary/package.json
+++ b/packages/adapters/cloudinary/package.json
@@ -58,6 +58,7 @@
     "clean": "rm -rf dist",
     "cp:resources": "cp ../../../LICENSE .",
     "test": "vitest run",
+    "test:bun": "pnpm bun test ./tests/bun",
     "test:deno": "deno test --config deno.test.json ./tests/deno",
     "ts:build": "tsc -p tsconfig.build.json",
     "vite:build": "vite build"

--- a/packages/adapters/cloudinary/package.json
+++ b/packages/adapters/cloudinary/package.json
@@ -58,6 +58,7 @@
     "clean": "rm -rf dist",
     "cp:resources": "cp ../../../LICENSE .",
     "test": "vitest run",
+    "test:deno": "deno test --config deno.test.json ./tests/deno",
     "ts:build": "tsc -p tsconfig.build.json",
     "vite:build": "vite build"
   },

--- a/packages/adapters/cloudinary/package.json
+++ b/packages/adapters/cloudinary/package.json
@@ -59,6 +59,7 @@
     "cp:resources": "cp ../../../LICENSE .",
     "test": "vitest run",
     "test:bun": "pnpm bun test ./tests/bun",
+    "test:cloudflare": "vitest run ./tests/cloudflare",
     "test:deno": "deno test --config deno.test.json ./tests/deno",
     "ts:build": "tsc -p tsconfig.build.json",
     "vite:build": "vite build"

--- a/packages/adapters/cloudinary/package.json
+++ b/packages/adapters/cloudinary/package.json
@@ -57,10 +57,11 @@
     "build": "pnpm vite:build && pnpm ts:build && pnpm api:build && pnpm api:docs && pnpm cp:resources",
     "clean": "rm -rf dist",
     "cp:resources": "cp ../../../LICENSE .",
-    "test": "vitest run",
+    "test": "pnpm test:node && pnpm test:bun && pnpm test:deno",
     "test:bun": "pnpm bun test ./tests/bun",
     "test:cloudflare": "vitest run ./tests/cloudflare",
     "test:deno": "deno test --config deno.test.json ./tests/deno",
+    "test:node": "vitest run",
     "ts:build": "tsc -p tsconfig.build.json",
     "vite:build": "vite build"
   },

--- a/packages/adapters/cloudinary/src/api-extractor.ts
+++ b/packages/adapters/cloudinary/src/api-extractor.ts
@@ -2,6 +2,6 @@
  * Official Cloudinary adapter package.
  * @packageDocumentation
  */
-export * from './index';
+export * from './index.ts';
 
-export * as register from './register';
+export * as register from './register.ts';

--- a/packages/adapters/cloudinary/src/index.ts
+++ b/packages/adapters/cloudinary/src/index.ts
@@ -1,1 +1,1 @@
-export {adapter as cloudinaryAdapter, adapter as default} from './core/adapter';
+export {adapter as cloudinaryAdapter, adapter as default} from './core/adapter.ts';

--- a/packages/adapters/cloudinary/src/register.ts
+++ b/packages/adapters/cloudinary/src/register.ts
@@ -1,5 +1,5 @@
 import {registerAdapters} from '@yoot/yoot';
-import {adapter} from './core/adapter';
+import {adapter} from './core/adapter.ts';
 /**
  * Automatic adapter registration for the Cloudinary adapter.
  * @packageDocumentation

--- a/packages/adapters/cloudinary/tests/bun/smoke.test.ts
+++ b/packages/adapters/cloudinary/tests/bun/smoke.test.ts
@@ -1,0 +1,15 @@
+import {expect, test} from 'bun:test';
+import adapter, {cloudinaryAdapter} from '../../src/index.ts';
+
+test('should initialize and have expected methods', () => {
+  // Verify default and named exports exist
+  expect(adapter).toBeDefined();
+  expect(cloudinaryAdapter).toBeDefined();
+
+  // Verify default export is the main named export
+  expect(adapter).toBe(cloudinaryAdapter);
+
+  // Verify core methods are present and are functions
+  expect(typeof adapter.supports).toBe('function');
+  expect(typeof adapter.generateUrl).toBe('function');
+});

--- a/packages/adapters/cloudinary/tests/cloudflare/smoke.test.ts
+++ b/packages/adapters/cloudinary/tests/cloudflare/smoke.test.ts
@@ -1,0 +1,27 @@
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {unstable_startWorker} from 'wrangler';
+import {afterAll, beforeAll, describe, expect, it} from '@yoot/test-kit';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe('Cloudinary Cloudflare Smoke Tests', () => {
+  let worker: Awaited<ReturnType<typeof unstable_startWorker>>;
+
+  beforeAll(async () => {
+    worker = await unstable_startWorker({
+      config: path.join(dirname, 'wrangler.toml'),
+    });
+  });
+
+  afterAll(async () => {
+    await worker.dispose();
+  });
+
+  it('should execute the fetch handler and internal assertion should pass', {timeout: 30_000}, async () => {
+    const response = await worker.fetch('http://localhost');
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('test success');
+  });
+});

--- a/packages/adapters/cloudinary/tests/cloudflare/worker.ts
+++ b/packages/adapters/cloudinary/tests/cloudflare/worker.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert';
+import adapter, {cloudinaryAdapter} from '../../src/index.ts';
+
+export default {
+  fetch() {
+    assert(typeof adapter !== 'undefined', 'Adapter is undefined');
+    assert.strictEqual(adapter, cloudinaryAdapter, 'Default export and named export are not the same');
+    // Verify core methods are present and are functions
+    assert(typeof adapter.supports === 'function', 'supports method is not a functiion');
+    assert(typeof adapter.generateUrl === 'function', 'generateUrl method is not a functiion');
+
+    return new Response('test success');
+  },
+};

--- a/packages/adapters/cloudinary/tests/cloudflare/wrangler.toml
+++ b/packages/adapters/cloudinary/tests/cloudflare/wrangler.toml
@@ -1,0 +1,4 @@
+name = 'cloudinary-adapter-worker'
+main = "worker.ts"
+compatibility_date = '2025-06-01'
+compatibility_flags = ['nodejs_compat_v2']

--- a/packages/adapters/cloudinary/tests/deno/smoke.test.ts
+++ b/packages/adapters/cloudinary/tests/deno/smoke.test.ts
@@ -1,0 +1,18 @@
+import {expect} from 'jsr:@std/expect';
+import {describe, it} from 'jsr:@std/testing/bdd';
+import adapter, {cloudinaryAdapter} from '../../src/index.ts';
+
+describe('Cloudinary Adapter Deno Smoke Tests', () => {
+  it('should initialize and have expected methods', () => {
+    // Verify default and named exports exist
+    expect(adapter).toBeDefined();
+    expect(cloudinaryAdapter).toBeDefined();
+
+    // Verify default export is the main named export
+    expect(adapter).toBe(cloudinaryAdapter);
+
+    // Verify core methods are present and are functions
+    expect(typeof adapter.supports).toBe('function');
+    expect(typeof adapter.generateUrl).toBe('function');
+  });
+});

--- a/packages/adapters/imgix/deno.test.json
+++ b/packages/adapters/imgix/deno.test.json
@@ -1,0 +1,9 @@
+{
+  "imports": {
+    "@yoot/yoot/internal": "../../yoot/src/internal.ts",
+    "@yoot/yoot": "../../yoot/src/index.ts"
+  },
+  "compilerOptions": {
+    "lib": ["deno.ns", "dom", "esnext"]
+  }
+}

--- a/packages/adapters/imgix/package.json
+++ b/packages/adapters/imgix/package.json
@@ -58,6 +58,7 @@
     "clean": "rm -rf dist",
     "cp:resources": "cp ../../../LICENSE .",
     "test": "vitest run",
+    "test:bun": "pnpm bun test ./tests/bun",
     "test:deno": "deno test --config deno.test.json ./tests/deno",
     "ts:build": "tsc -p tsconfig.build.json",
     "vite:build": "vite build"

--- a/packages/adapters/imgix/package.json
+++ b/packages/adapters/imgix/package.json
@@ -58,6 +58,7 @@
     "clean": "rm -rf dist",
     "cp:resources": "cp ../../../LICENSE .",
     "test": "vitest run",
+    "test:deno": "deno test --config deno.test.json ./tests/deno",
     "ts:build": "tsc -p tsconfig.build.json",
     "vite:build": "vite build"
   },

--- a/packages/adapters/imgix/package.json
+++ b/packages/adapters/imgix/package.json
@@ -59,6 +59,7 @@
     "cp:resources": "cp ../../../LICENSE .",
     "test": "vitest run",
     "test:bun": "pnpm bun test ./tests/bun",
+    "test:cloudflare": "vitest run ./tests/cloudflare",
     "test:deno": "deno test --config deno.test.json ./tests/deno",
     "ts:build": "tsc -p tsconfig.build.json",
     "vite:build": "vite build"

--- a/packages/adapters/imgix/package.json
+++ b/packages/adapters/imgix/package.json
@@ -57,10 +57,11 @@
     "build": "pnpm vite:build && pnpm ts:build && pnpm api:build && pnpm api:docs && pnpm cp:resources",
     "clean": "rm -rf dist",
     "cp:resources": "cp ../../../LICENSE .",
-    "test": "vitest run",
+    "test": "pnpm test:node && pnpm test:bun && pnpm test:deno",
     "test:bun": "pnpm bun test ./tests/bun",
     "test:cloudflare": "vitest run ./tests/cloudflare",
     "test:deno": "deno test --config deno.test.json ./tests/deno",
+    "test:node": "vitest run",
     "ts:build": "tsc -p tsconfig.build.json",
     "vite:build": "vite build"
   },

--- a/packages/adapters/imgix/src/api-extractor.ts
+++ b/packages/adapters/imgix/src/api-extractor.ts
@@ -2,6 +2,6 @@
  * Official Imgix adapter package.
  * @packageDocumentation
  */
-export * from './index';
+export * from './index.ts';
 
-export * as register from './register';
+export * as register from './register.ts';

--- a/packages/adapters/imgix/src/index.ts
+++ b/packages/adapters/imgix/src/index.ts
@@ -1,1 +1,1 @@
-export {adapter as imgixAdapter, adapter as default} from './core/adapter';
+export {adapter as imgixAdapter, adapter as default} from './core/adapter.ts';

--- a/packages/adapters/imgix/src/register.ts
+++ b/packages/adapters/imgix/src/register.ts
@@ -1,5 +1,5 @@
 import {registerAdapters} from '@yoot/yoot';
-import {adapter} from './core/adapter';
+import {adapter} from './core/adapter.ts';
 
 export {};
 

--- a/packages/adapters/imgix/tests/bun/smoke.test.ts
+++ b/packages/adapters/imgix/tests/bun/smoke.test.ts
@@ -1,0 +1,15 @@
+import {expect, test} from 'bun:test';
+import adapter, {imgixAdapter} from '../../src/index.ts';
+
+test('should initialize and have expected methods', () => {
+  // Verify default and named exports exist
+  expect(adapter).toBeDefined();
+  expect(imgixAdapter).toBeDefined();
+
+  // Verify default export is the main named export
+  expect(adapter).toBe(imgixAdapter);
+
+  // Verify core methods are present and are functions
+  expect(typeof adapter.supports).toBe('function');
+  expect(typeof adapter.generateUrl).toBe('function');
+});

--- a/packages/adapters/imgix/tests/cloudflare/smoke.test.ts
+++ b/packages/adapters/imgix/tests/cloudflare/smoke.test.ts
@@ -1,0 +1,27 @@
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {unstable_startWorker} from 'wrangler';
+import {afterAll, beforeAll, describe, expect, it} from '@yoot/test-kit';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe('Imgix Cloudflare Smoke Tests', () => {
+  let worker: Awaited<ReturnType<typeof unstable_startWorker>>;
+
+  beforeAll(async () => {
+    worker = await unstable_startWorker({
+      config: path.join(dirname, 'wrangler.toml'),
+    });
+  });
+
+  afterAll(async () => {
+    await worker.dispose();
+  });
+
+  it('should execute the fetch handler and internal assertion should pass', {timeout: 30_000}, async () => {
+    const response = await worker.fetch('http://localhost');
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('test success');
+  });
+});

--- a/packages/adapters/imgix/tests/cloudflare/worker.ts
+++ b/packages/adapters/imgix/tests/cloudflare/worker.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert';
+import adapter, {imgixAdapter} from '../../src/index.ts';
+
+export default {
+  fetch() {
+    assert(typeof adapter !== 'undefined', 'Adapter is undefined');
+    assert.strictEqual(adapter, imgixAdapter, 'Default export and named export are not the same');
+    // Verify core methods are present and are functions
+    assert(typeof adapter.supports === 'function', 'supports method is not a functiion');
+    assert(typeof adapter.generateUrl === 'function', 'generateUrl method is not a functiion');
+
+    return new Response('test success');
+  },
+};

--- a/packages/adapters/imgix/tests/cloudflare/wrangler.toml
+++ b/packages/adapters/imgix/tests/cloudflare/wrangler.toml
@@ -1,0 +1,4 @@
+name = 'imgix-adapter-worker'
+main = "worker.ts"
+compatibility_date = '2025-06-01'
+compatibility_flags = ['nodejs_compat_v2']

--- a/packages/adapters/imgix/tests/deno/smoke.test.ts
+++ b/packages/adapters/imgix/tests/deno/smoke.test.ts
@@ -1,0 +1,18 @@
+import {expect} from 'jsr:@std/expect';
+import {describe, it} from 'jsr:@std/testing/bdd';
+import adapter, {imgixAdapter} from '../../src/index.ts';
+
+describe('Imgix Adapter Deno Smoke Tests', () => {
+  it('should initialize and have expected methods', () => {
+    // Verify default and named exports exist
+    expect(adapter).toBeDefined();
+    expect(imgixAdapter).toBeDefined();
+
+    // Verify default export is the main named export
+    expect(adapter).toBe(imgixAdapter);
+
+    // Verify core methods are present and are functions
+    expect(typeof adapter.supports).toBe('function');
+    expect(typeof adapter.generateUrl).toBe('function');
+  });
+});

--- a/packages/adapters/sanity/deno.test.json
+++ b/packages/adapters/sanity/deno.test.json
@@ -1,0 +1,9 @@
+{
+  "imports": {
+    "@yoot/yoot/internal": "../../yoot/src/internal.ts",
+    "@yoot/yoot": "../../yoot/src/index.ts"
+  },
+  "compilerOptions": {
+    "lib": ["deno.ns", "dom", "esnext"]
+  }
+}

--- a/packages/adapters/sanity/package.json
+++ b/packages/adapters/sanity/package.json
@@ -58,6 +58,7 @@
     "clean": "rm -rf dist",
     "cp:resources": "cp ../../../LICENSE .",
     "test": "vitest run",
+    "test:bun": "pnpm bun test ./tests/bun",
     "test:deno": "deno test --config deno.test.json ./tests/deno",
     "ts:build": "tsc -p tsconfig.build.json",
     "vite:build": "vite build"

--- a/packages/adapters/sanity/package.json
+++ b/packages/adapters/sanity/package.json
@@ -58,6 +58,7 @@
     "clean": "rm -rf dist",
     "cp:resources": "cp ../../../LICENSE .",
     "test": "vitest run",
+    "test:deno": "deno test --config deno.test.json ./tests/deno",
     "ts:build": "tsc -p tsconfig.build.json",
     "vite:build": "vite build"
   },

--- a/packages/adapters/sanity/package.json
+++ b/packages/adapters/sanity/package.json
@@ -59,6 +59,7 @@
     "cp:resources": "cp ../../../LICENSE .",
     "test": "vitest run",
     "test:bun": "pnpm bun test ./tests/bun",
+    "test:cloudflare": "vitest run ./tests/cloudflare",
     "test:deno": "deno test --config deno.test.json ./tests/deno",
     "ts:build": "tsc -p tsconfig.build.json",
     "vite:build": "vite build"

--- a/packages/adapters/sanity/package.json
+++ b/packages/adapters/sanity/package.json
@@ -57,10 +57,11 @@
     "build": "pnpm vite:build && pnpm ts:build && pnpm api:build && pnpm api:docs && pnpm cp:resources",
     "clean": "rm -rf dist",
     "cp:resources": "cp ../../../LICENSE .",
-    "test": "vitest run",
+    "test": "pnpm test:node && pnpm test:bun && pnpm test:deno",
     "test:bun": "pnpm bun test ./tests/bun",
     "test:cloudflare": "vitest run ./tests/cloudflare",
     "test:deno": "deno test --config deno.test.json ./tests/deno",
+    "test:node": "vitest run",
     "ts:build": "tsc -p tsconfig.build.json",
     "vite:build": "vite build"
   },

--- a/packages/adapters/sanity/src/api-extractor.ts
+++ b/packages/adapters/sanity/src/api-extractor.ts
@@ -2,6 +2,6 @@
  * Official Sanity adapter package.
  * @packageDocumentation
  */
-export * from './index';
+export * from './index.ts';
 
-export * as register from './register';
+export * as register from './register.ts';

--- a/packages/adapters/sanity/src/index.ts
+++ b/packages/adapters/sanity/src/index.ts
@@ -1,1 +1,1 @@
-export {adapter as sanityAdapter, adapter as default} from './core/adapter';
+export {adapter as sanityAdapter, adapter as default} from './core/adapter.ts';

--- a/packages/adapters/sanity/src/register.ts
+++ b/packages/adapters/sanity/src/register.ts
@@ -1,5 +1,5 @@
 import {registerAdapters} from '@yoot/yoot';
-import {adapter} from './core/adapter';
+import {adapter} from './core/adapter.ts';
 
 export {};
 

--- a/packages/adapters/sanity/tests/bun/smoke.test.ts
+++ b/packages/adapters/sanity/tests/bun/smoke.test.ts
@@ -1,0 +1,15 @@
+import {expect, test} from 'bun:test';
+import adapter, {sanityAdapter} from '../../src/index.ts';
+
+test('should initialize and have expected methods', () => {
+  // Verify default and named exports exist
+  expect(adapter).toBeDefined();
+  expect(sanityAdapter).toBeDefined();
+
+  // Verify default export is the main named export
+  expect(adapter).toBe(sanityAdapter);
+
+  // Verify core methods are present and are functions
+  expect(typeof adapter.supports).toBe('function');
+  expect(typeof adapter.generateUrl).toBe('function');
+});

--- a/packages/adapters/sanity/tests/cloudflare/smoke.test.ts
+++ b/packages/adapters/sanity/tests/cloudflare/smoke.test.ts
@@ -1,0 +1,27 @@
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {unstable_startWorker} from 'wrangler';
+import {afterAll, beforeAll, describe, expect, it} from '@yoot/test-kit';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe('Sanity Cloudflare Smoke Tests', () => {
+  let worker: Awaited<ReturnType<typeof unstable_startWorker>>;
+
+  beforeAll(async () => {
+    worker = await unstable_startWorker({
+      config: path.join(dirname, 'wrangler.toml'),
+    });
+  });
+
+  afterAll(async () => {
+    await worker.dispose();
+  });
+
+  it('should execute the fetch handler and internal assertion should pass', {timeout: 30_000}, async () => {
+    const response = await worker.fetch('http://localhost');
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('test success');
+  });
+});

--- a/packages/adapters/sanity/tests/cloudflare/worker.ts
+++ b/packages/adapters/sanity/tests/cloudflare/worker.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert';
+import adapter, {sanityAdapter} from '../../src/index.ts';
+
+export default {
+  fetch() {
+    assert(typeof adapter !== 'undefined', 'Adapter is undefined');
+    assert.strictEqual(adapter, sanityAdapter, 'Default export and named export are not the same');
+    // Verify core methods are present and are functions
+    assert(typeof adapter.supports === 'function', 'supports method is not a functiion');
+    assert(typeof adapter.generateUrl === 'function', 'generateUrl method is not a functiion');
+
+    return new Response('test success');
+  },
+};

--- a/packages/adapters/sanity/tests/cloudflare/wrangler.toml
+++ b/packages/adapters/sanity/tests/cloudflare/wrangler.toml
@@ -1,0 +1,4 @@
+name = 'sanity-adapter-worker'
+main = "worker.ts"
+compatibility_date = '2025-06-01'
+compatibility_flags = ['nodejs_compat_v2']

--- a/packages/adapters/sanity/tests/deno/smoke.test.ts
+++ b/packages/adapters/sanity/tests/deno/smoke.test.ts
@@ -1,0 +1,18 @@
+import {expect} from 'jsr:@std/expect';
+import {describe, it} from 'jsr:@std/testing/bdd';
+import adapter, {sanityAdapter} from '../../src/index.ts';
+
+describe('Sanity Adapter Deno Smoke Tests', () => {
+  it('should initialize and have expected methods', () => {
+    // Verify default and named exports exist
+    expect(adapter).toBeDefined();
+    expect(sanityAdapter).toBeDefined();
+
+    // Verify default export is the main named export
+    expect(adapter).toBe(sanityAdapter);
+
+    // Verify core methods are present and are functions
+    expect(typeof adapter.supports).toBe('function');
+    expect(typeof adapter.generateUrl).toBe('function');
+  });
+});

--- a/packages/adapters/shopify/deno.test.json
+++ b/packages/adapters/shopify/deno.test.json
@@ -1,0 +1,9 @@
+{
+  "imports": {
+    "@yoot/yoot/internal": "../../yoot/src/internal.ts",
+    "@yoot/yoot": "../../yoot/src/index.ts"
+  },
+  "compilerOptions": {
+    "lib": ["deno.ns", "dom", "esnext"]
+  }
+}

--- a/packages/adapters/shopify/package.json
+++ b/packages/adapters/shopify/package.json
@@ -58,6 +58,7 @@
     "clean": "rm -rf dist",
     "cp:resources": "cp ../../../LICENSE .",
     "test": "vitest run",
+    "test:bun": "pnpm bun test ./tests/bun",
     "test:deno": "deno test --config deno.test.json ./tests/deno",
     "ts:build": "tsc -p tsconfig.build.json",
     "vite:build": "vite build"

--- a/packages/adapters/shopify/package.json
+++ b/packages/adapters/shopify/package.json
@@ -58,6 +58,7 @@
     "clean": "rm -rf dist",
     "cp:resources": "cp ../../../LICENSE .",
     "test": "vitest run",
+    "test:deno": "deno test --config deno.test.json ./tests/deno",
     "ts:build": "tsc -p tsconfig.build.json",
     "vite:build": "vite build"
   },

--- a/packages/adapters/shopify/package.json
+++ b/packages/adapters/shopify/package.json
@@ -59,6 +59,7 @@
     "cp:resources": "cp ../../../LICENSE .",
     "test": "vitest run",
     "test:bun": "pnpm bun test ./tests/bun",
+    "test:cloudflare": "vitest run ./tests/cloudflare",
     "test:deno": "deno test --config deno.test.json ./tests/deno",
     "ts:build": "tsc -p tsconfig.build.json",
     "vite:build": "vite build"

--- a/packages/adapters/shopify/package.json
+++ b/packages/adapters/shopify/package.json
@@ -57,10 +57,11 @@
     "build": "pnpm vite:build && pnpm ts:build && pnpm api:build && pnpm api:docs && pnpm cp:resources",
     "clean": "rm -rf dist",
     "cp:resources": "cp ../../../LICENSE .",
-    "test": "vitest run",
+    "test": "pnpm test:node && pnpm test:bun && pnpm test:deno",
     "test:bun": "pnpm bun test ./tests/bun",
     "test:cloudflare": "vitest run ./tests/cloudflare",
     "test:deno": "deno test --config deno.test.json ./tests/deno",
+    "test:node": "vitest run",
     "ts:build": "tsc -p tsconfig.build.json",
     "vite:build": "vite build"
   },

--- a/packages/adapters/shopify/src/api-extractor.ts
+++ b/packages/adapters/shopify/src/api-extractor.ts
@@ -2,6 +2,6 @@
  * Official Shopify adapter package.
  * @packageDocumentation
  */
-export * from './index';
+export * from './index.ts';
 
-export * as register from './register';
+export * as register from './register.ts';

--- a/packages/adapters/shopify/src/index.ts
+++ b/packages/adapters/shopify/src/index.ts
@@ -1,1 +1,1 @@
-export {adapter as shopifyAdapter, adapter as default} from './core/adapter';
+export {adapter as shopifyAdapter, adapter as default} from './core/adapter.ts';

--- a/packages/adapters/shopify/src/register.ts
+++ b/packages/adapters/shopify/src/register.ts
@@ -1,5 +1,5 @@
 import {registerAdapters} from '@yoot/yoot';
-import {adapter} from './core/adapter';
+import {adapter} from './core/adapter.ts';
 
 export {};
 

--- a/packages/adapters/shopify/tests/bun/smoke.test.ts
+++ b/packages/adapters/shopify/tests/bun/smoke.test.ts
@@ -1,0 +1,15 @@
+import {expect, test} from 'bun:test';
+import adapter, {shopifyAdapter} from '../../src/index.ts';
+
+test('should initialize and have expected methods', () => {
+  // Verify default and named exports exist
+  expect(adapter).toBeDefined();
+  expect(shopifyAdapter).toBeDefined();
+
+  // Verify default export is the main named export
+  expect(adapter).toBe(shopifyAdapter);
+
+  // Verify core methods are present and are functions
+  expect(typeof adapter.supports).toBe('function');
+  expect(typeof adapter.generateUrl).toBe('function');
+});

--- a/packages/adapters/shopify/tests/cloudflare/smoke.test.ts
+++ b/packages/adapters/shopify/tests/cloudflare/smoke.test.ts
@@ -1,0 +1,27 @@
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {unstable_startWorker} from 'wrangler';
+import {afterAll, beforeAll, describe, expect, it} from '@yoot/test-kit';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe('Shopify Cloudflare Smoke Tests', () => {
+  let worker: Awaited<ReturnType<typeof unstable_startWorker>>;
+
+  beforeAll(async () => {
+    worker = await unstable_startWorker({
+      config: path.join(dirname, 'wrangler.toml'),
+    });
+  });
+
+  afterAll(async () => {
+    await worker.dispose();
+  });
+
+  it('should execute the fetch handler and internal assertion should pass', {timeout: 30_000}, async () => {
+    const response = await worker.fetch('http://localhost');
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('test success');
+  });
+});

--- a/packages/adapters/shopify/tests/cloudflare/worker.ts
+++ b/packages/adapters/shopify/tests/cloudflare/worker.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert';
+import adapter, {shopifyAdapter} from '../../src/index.ts';
+
+export default {
+  fetch() {
+    assert(typeof adapter !== 'undefined', 'Adapter is undefined');
+    assert.strictEqual(adapter, shopifyAdapter, 'Default export and named export are not the same');
+    // Verify core methods are present and are functions
+    assert(typeof adapter.supports === 'function', 'supports method is not a functiion');
+    assert(typeof adapter.generateUrl === 'function', 'generateUrl method is not a functiion');
+
+    return new Response('test success');
+  },
+};

--- a/packages/adapters/shopify/tests/cloudflare/wrangler.toml
+++ b/packages/adapters/shopify/tests/cloudflare/wrangler.toml
@@ -1,0 +1,4 @@
+name = 'shopify-adapter-worker'
+main = "worker.ts"
+compatibility_date = '2025-06-01'
+compatibility_flags = ['nodejs_compat_v2']

--- a/packages/adapters/shopify/tests/deno/smoke.test.ts
+++ b/packages/adapters/shopify/tests/deno/smoke.test.ts
@@ -1,0 +1,18 @@
+import {expect} from 'jsr:@std/expect';
+import {describe, it} from 'jsr:@std/testing/bdd';
+import adapter, {shopifyAdapter} from '../../src/index.ts';
+
+describe('Shopify Adapter Deno Smoke Tests', () => {
+  it('should initialize and have expected methods', () => {
+    // Verify default and named exports exist
+    expect(adapter).toBeDefined();
+    expect(shopifyAdapter).toBeDefined();
+
+    // Verify default export is the main named export
+    expect(adapter).toBe(shopifyAdapter);
+
+    // Verify core methods are present and are functions
+    expect(typeof adapter.supports).toBe('function');
+    expect(typeof adapter.generateUrl).toBe('function');
+  });
+});

--- a/packages/test-kit/src/index.ts
+++ b/packages/test-kit/src/index.ts
@@ -1,4 +1,4 @@
-export {beforeAll, beforeEach, describe, expect, it} from 'vitest';
+export {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it} from 'vitest';
 export {applyInputDefaults, defineCases, expectParams, expectString, inject, runTestCase, testEach} from './tools';
 export type {Expected, ExpectParams, ExpectString, TestCase} from './tools';
 export {createTemplate, divide, multiply} from './utils';

--- a/packages/yoot/deno.test.json
+++ b/packages/yoot/deno.test.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "lib": ["deno.ns", "dom", "esnext"]
+  }
+}

--- a/packages/yoot/package.json
+++ b/packages/yoot/package.json
@@ -69,6 +69,7 @@
     "clean": "rm -rf dist",
     "cp:resources": "cp ../../LICENSE .",
     "test": "vitest run",
+    "test:deno": "deno test --config deno.test.json ./tests/deno",
     "ts:build": "tsc -p tsconfig.build.json",
     "vite:build": "vite build"
   },

--- a/packages/yoot/package.json
+++ b/packages/yoot/package.json
@@ -69,6 +69,7 @@
     "clean": "rm -rf dist",
     "cp:resources": "cp ../../LICENSE .",
     "test": "vitest run",
+    "test:bun": "pnpm bun test ./tests/bun",
     "test:deno": "deno test --config deno.test.json ./tests/deno",
     "ts:build": "tsc -p tsconfig.build.json",
     "vite:build": "vite build"

--- a/packages/yoot/package.json
+++ b/packages/yoot/package.json
@@ -68,10 +68,11 @@
     "build": "pnpm vite:build && pnpm ts:build && pnpm cp:resources && pnpm api:build && pnpm api:docs",
     "clean": "rm -rf dist",
     "cp:resources": "cp ../../LICENSE .",
-    "test": "vitest run",
+    "test": "pnpm test:node && pnpm test:bun && pnpm test:deno",
     "test:bun": "pnpm bun test ./tests/bun",
     "test:cloudflare": "vitest run ./tests/cloudflare",
     "test:deno": "deno test --config deno.test.json ./tests/deno",
+    "test:node": "vitest run",
     "ts:build": "tsc -p tsconfig.build.json",
     "vite:build": "vite build"
   },

--- a/packages/yoot/package.json
+++ b/packages/yoot/package.json
@@ -70,6 +70,7 @@
     "cp:resources": "cp ../../LICENSE .",
     "test": "vitest run",
     "test:bun": "pnpm bun test ./tests/bun",
+    "test:cloudflare": "vitest run ./tests/cloudflare",
     "test:deno": "deno test --config deno.test.json ./tests/deno",
     "ts:build": "tsc -p tsconfig.build.json",
     "vite:build": "vite build"

--- a/packages/yoot/src/api-extractor.ts
+++ b/packages/yoot/src/api-extractor.ts
@@ -2,23 +2,23 @@
  * Core `yoot` API.
  * @packageDocumentation
  */
-export * from './index'; // Assumes './index.ts' exports the curated public core API
+export * from './index.ts';
 
 /**
  * JSX utilities for `yoot` (React, SolidJS, etc.).
  * @packageDocumentation
  */
-export * as jsx from './jsx';
+export * as jsx from './jsx.ts';
 
 /**
  * HTML utilities for `yoot` (Astro, Svelte, etc.).
  * @packageDocumentation
  */
-export * as html from './html';
+export * as html from './html.ts';
 
 /**
  * INTERNAL USE ONLY. For `yoot` adapters. Not for public use.
  * @packageDocumentation
  * @internal
  */
-export * as internal from './internal';
+export * as internal from './internal.ts';

--- a/packages/yoot/src/core/adapter.ts
+++ b/packages/yoot/src/core/adapter.ts
@@ -1,7 +1,7 @@
-import type {Directives, YootState, PrimeStateInput} from './yoot';
-import {_getConfig as getConfig} from './config';
-import {adapterStore} from './store';
-import {invariant} from './utils';
+import type {Directives, YootState, PrimeStateInput} from './yoot.ts';
+import {_getConfig as getConfig} from './config.ts';
+import {adapterStore} from './store.ts';
+import {invariant} from './utils.ts';
 
 // --- Module Exports ---
 export {createAdapter, passThroughAdapter, registerAdapters};

--- a/packages/yoot/src/core/config.ts
+++ b/packages/yoot/src/core/config.ts
@@ -1,4 +1,4 @@
-import type {Adapter} from './adapter';
+import type {Adapter} from './adapter.ts';
 
 // -- Module Exports --
 export {defineConfig, mergeConfig};

--- a/packages/yoot/src/core/helpers.ts
+++ b/packages/yoot/src/core/helpers.ts
@@ -1,7 +1,7 @@
-import type {GenerateUrlInput} from './adapter';
-import type {Directives, Yoot, YootState} from './yoot';
-import type {HTMLImageAttributes, HTMLSourceAttributes, Maybe, Prettify} from './types';
-import {isKeyOf, isFunction, hasIntrinsicDimensions, invariant, isNumber, isString, isNullish} from './utils';
+import type {GenerateUrlInput} from './adapter.ts';
+import type {Directives, Yoot, YootState} from './yoot.ts';
+import type {HTMLImageAttributes, HTMLSourceAttributes, Maybe, Prettify} from './types.ts';
+import {isKeyOf, isFunction, hasIntrinsicDimensions, invariant, isNumber, isString, isNullish} from './utils.ts';
 
 export {
   buildSrcSet,

--- a/packages/yoot/src/core/html.ts
+++ b/packages/yoot/src/core/html.ts
@@ -1,4 +1,4 @@
-import {getImgAttrs as _getImgAttrs, getSourceAttrs as _getSourceAttrs} from './helpers';
+import {getImgAttrs as _getImgAttrs, getSourceAttrs as _getSourceAttrs} from './helpers.ts';
 import type {
   BuildSrcSetOptions,
   ImgAttrs as _ImgAttrs,
@@ -6,12 +6,12 @@ import type {
   SourceAttrs as _SourceAttrs,
   SourceAttrsOptions,
   WithSrcSetBuilder,
-} from './helpers';
-import type {Yoot} from './yoot';
-import {isEmpty, isNullish} from './utils';
+} from './helpers.ts';
+import type {Yoot} from './yoot.ts';
+import {isEmpty, isNullish} from './utils.ts';
 
 // -- Module Exports --
-export {buildSrcSet, defineSrcSetBuilder} from './helpers';
+export {buildSrcSet, defineSrcSetBuilder} from './helpers.ts';
 export {getImgAttrs, getSourceAttrs, withImgAttrs, withSourceAttrs};
 export type {BuildSrcSetOptions, ImgAttrs, ImgAttrsOptions, SourceAttrs, SourceAttrsOptions, WithSrcSetBuilder};
 // For testing purposes

--- a/packages/yoot/src/core/store.ts
+++ b/packages/yoot/src/core/store.ts
@@ -1,4 +1,4 @@
-import type {Adapter} from './adapter';
+import type {Adapter} from './adapter.ts';
 
 // -- Module Exports --
 export {adapterStore, YOOT_BRAND};

--- a/packages/yoot/src/core/yoot.ts
+++ b/packages/yoot/src/core/yoot.ts
@@ -1,7 +1,7 @@
-import {_getAdapter as getAdapter} from './adapter';
-import {mustBeOneOf, mustBeInRange, normalizeDirectives} from './helpers';
-import {YOOT_BRAND} from './store';
-import {invariant, isNullish, isNumber, isString} from './utils';
+import {_getAdapter as getAdapter} from './adapter.ts';
+import {mustBeOneOf, mustBeInRange, normalizeDirectives} from './helpers.ts';
+import {YOOT_BRAND} from './store.ts';
+import {invariant, isNullish, isNumber, isString} from './utils.ts';
 
 // -- Module Exports --
 // API function and helpers

--- a/packages/yoot/src/html.ts
+++ b/packages/yoot/src/html.ts
@@ -1,1 +1,1 @@
-export * from './core/html';
+export * from './core/html.ts';

--- a/packages/yoot/src/index.ts
+++ b/packages/yoot/src/index.ts
@@ -1,8 +1,8 @@
-export {yoot} from './core/yoot';
-export type * from './core/yoot';
+export {yoot} from './core/yoot.ts';
+export type * from './core/yoot.ts';
 
-export {createAdapter, passThroughAdapter, registerAdapters} from './core/adapter';
-export type * from './core/adapter';
+export {createAdapter, passThroughAdapter, registerAdapters} from './core/adapter.ts';
+export type * from './core/adapter.ts';
 
-export {defineConfig, mergeConfig, type YootConfig} from './core/config';
-export {hasIntrinsicDimensions} from './core/utils';
+export {defineConfig, mergeConfig, type YootConfig} from './core/config.ts';
+export {hasIntrinsicDimensions} from './core/utils.ts';

--- a/packages/yoot/src/internal.ts
+++ b/packages/yoot/src/internal.ts
@@ -10,4 +10,4 @@ export {
   isNullish as _isNullish,
   isNumber as _isNumber,
   isString as _isString,
-} from './core/utils';
+} from './core/utils.ts';

--- a/packages/yoot/src/jsx.ts
+++ b/packages/yoot/src/jsx.ts
@@ -5,5 +5,5 @@ export {
   getSourceAttrs,
   withImgAttrs,
   withSourceAttrs,
-} from './core/helpers';
-export type * from './core/helpers';
+} from './core/helpers.ts';
+export type * from './core/helpers.ts';

--- a/packages/yoot/tests/bun/smoke.test.ts
+++ b/packages/yoot/tests/bun/smoke.test.ts
@@ -1,0 +1,59 @@
+import {expect, test} from 'bun:test';
+import {yoot, createAdapter, registerAdapters} from '../../src/index.ts';
+import * as html from '../../src/html.ts';
+import * as jsx from '../../src/jsx.ts';
+
+test('yoot factory should initialize and return a valid instance with core methods', () => {
+  expect(yoot).toBeDefined();
+  expect(typeof yoot).toBe('function');
+
+  const ute = yoot('https://cdn.example.com/file.png');
+
+  expect(typeof ute).toBe('function');
+  expect(typeof ute.src).toBe('function');
+  expect(typeof ute.alt).toBe('function');
+  // Directive methods
+  expect(typeof ute.aspectRatio).toBe('function');
+  expect(typeof ute.crop).toBe('function');
+  expect(typeof ute.fit).toBe('function');
+  expect(typeof ute.format).toBe('function');
+  expect(typeof ute.height).toBe('function');
+  expect(typeof ute.h).toBe('function');
+  expect(typeof ute.width).toBe('function');
+  expect(typeof ute.w).toBe('function');
+  // Output methods
+  expect(typeof ute.toJSON).toBe('function');
+  expect(typeof ute.toString).toBe('function');
+});
+
+test('should create and register an adapter', () => {
+  expect(typeof createAdapter).toBe('function');
+  expect(typeof registerAdapters).toBe('function');
+
+  expect(() => registerAdapters()).not.toThrow();
+
+  const adapter = createAdapter({
+    supports: () => true,
+    generateUrl: ({src}) => src,
+  });
+
+  expect(() => registerAdapters(adapter)).not.toThrow();
+});
+
+test('JSX utilities should have expected methods', () => {
+  expect(typeof jsx.buildSrcSet).toBe('function');
+  expect(typeof jsx.defineSrcSetBuilder).toBe('function');
+  expect(typeof jsx.getImgAttrs).toBe('function');
+  expect(typeof jsx.getSourceAttrs).toBe('function');
+  expect(typeof jsx.withImgAttrs).toBe('function');
+  expect(typeof jsx.withSourceAttrs).toBe('function');
+});
+
+test('HTML utilities should have expected methods', () => {
+  expect(typeof html.buildSrcSet).toBe('function');
+  expect(typeof html.defineSrcSetBuilder).toBe('function');
+  expect(typeof html.getImgAttrs).toBe('function');
+  expect(typeof html.getSourceAttrs).toBe('function');
+  expect(typeof html.withImgAttrs).toBe('function');
+  expect(typeof html.withSourceAttrs).toBe('function');
+});

--- a/packages/yoot/tests/cloudflare/smoke.test.ts
+++ b/packages/yoot/tests/cloudflare/smoke.test.ts
@@ -1,0 +1,29 @@
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {unstable_startWorker} from 'wrangler';
+import {afterAll, beforeAll, describe, expect, it} from '@yoot/test-kit';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe('Yoot Cloudflare Smoke Tests', () => {
+  let worker: Awaited<ReturnType<typeof unstable_startWorker>>;
+
+  beforeAll(async () => {
+    worker = await unstable_startWorker({
+      config: path.join(dirname, 'wrangler.toml'),
+    });
+  });
+
+  afterAll(async () => {
+    await worker.dispose();
+  });
+
+  it('should execute the fetch handler and internal assertion should pass', {timeout: 30_000}, () => {
+    expect(async () => {
+      const response = await worker.fetch('http://localhost');
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe('test success');
+    }).not.toThrow();
+  });
+});

--- a/packages/yoot/tests/cloudflare/worker.ts
+++ b/packages/yoot/tests/cloudflare/worker.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert';
+import {yoot, createAdapter, registerAdapters} from '../../src/index.ts';
+import * as html from '../../src/html.ts';
+import * as jsx from '../../src/jsx.ts';
+
+const IMAGE_URL = 'https://cdn.example.com/file.png';
+
+export default {
+  fetch() {
+    // Test yoot factory
+    assert.equal(typeof yoot, 'function', 'Expected yoot to be a function');
+    const ute = yoot(IMAGE_URL);
+    assert.equal(typeof ute, 'function', 'Expected ute to be a function');
+
+    // Test `ute` attributes methods
+    assert.equal(typeof ute.src, 'function', 'Expected ute.src to be a function');
+    assert.equal(typeof ute.alt, 'function', 'Expected ute.alt to be a function');
+
+    // Test `ute` directive methods
+    assert.equal(typeof ute.aspectRatio, 'function', 'Expected ute.aspectRatio to be a function');
+    assert.equal(typeof ute.crop, 'function', 'Expected ute.crop to be a function');
+    assert.equal(typeof ute.fit, 'function', 'Expected ute.fit to be a function');
+    assert.equal(typeof ute.format, 'function', 'Expected ute.format to be a function');
+    assert.equal(typeof ute.height, 'function', 'Expected ute.height to be a function');
+    assert.equal(typeof ute.h, 'function', 'Expected ute.h to be a function');
+    assert.equal(typeof ute.width, 'function', 'Expected ute.width to be a function');
+    assert.equal(typeof ute.w, 'function', 'Expected ute.w to be a function');
+
+    // Test `ute` output methods
+    assert.equal(typeof ute.toJSON, 'function', 'Expected ute.toJSON to be a function');
+    assert.equal(typeof ute.toString, 'function', 'Expected ute.toString to be a function');
+
+    // Test ute.toString() output
+    const url = ute.toString();
+    assert.equal(typeof url, 'string', 'Expected URL from ute.toString() to be a string');
+    assert.equal(url, IMAGE_URL, 'Expected URL to match the input');
+
+    // -- Verify adapter creation and registration --
+    // Test Adapter factory methods
+    assert.equal(typeof createAdapter, 'function', 'Expected createAdapter to be a function');
+    assert.equal(typeof registerAdapters, 'function', 'Expected registerAdapters to be a function');
+
+    // Test createAdapter
+    assert.doesNotThrow(() => {
+      createAdapter({
+        supports: () => true,
+        generateUrl: ({src}) => src,
+      });
+    }, 'Expected createAdapter to not throw');
+
+    // Create an adapter for further checks
+    const adapter = createAdapter({
+      supports: () => true,
+      generateUrl: ({src}) => src,
+    });
+
+    assert.ok(typeof adapter === 'object' && adapter !== null, 'Expected adapter instance to be a non-null object');
+    assert.equal(typeof adapter.supports, 'function', 'Expected adapter.supports to be a function');
+    assert.equal(typeof adapter.generateUrl, 'function', 'Expected adapter.generateUrl to be a function');
+
+    // Verify adapter registration
+    assert.doesNotThrow(() => registerAdapters(adapter), 'Expected registerAdapters(adapter) to not throw');
+    assert.doesNotThrow(() => registerAdapters(), 'Expected registerAdapters() to not throw without arguments');
+
+    // -- HTML/JSX Utilities --
+    // For each utility, check its type and then assert if html and jsx versions are the same
+    assert.equal(typeof html.buildSrcSet, 'function', 'Expected html.buildSrcSet to be a function');
+    assert.equal(typeof jsx.buildSrcSet, 'function', 'Expected jsx.buildSrcSet to be a function');
+
+    assert.equal(typeof html.defineSrcSetBuilder, 'function', 'Expected html.defineSrcSetBuilder to be a function');
+    assert.equal(typeof jsx.defineSrcSetBuilder, 'function', 'Expected jsx.defineSrcSetBuilder to be a function');
+
+    assert.equal(typeof html.getImgAttrs, 'function', 'Expected html.getImgAttrs to be a function');
+    assert.equal(typeof jsx.getImgAttrs, 'function', 'Expected jsx.getImgAttrs to be a function');
+
+    assert.equal(typeof html.getSourceAttrs, 'function', 'Expected html.getSourceAttrs to be a function');
+    assert.equal(typeof jsx.getSourceAttrs, 'function', 'Expected jsx.getSourceAttrs to be a function');
+
+    assert.equal(typeof html.withImgAttrs, 'function', 'Expected html.withImgAttrs to be a function');
+    assert.equal(typeof jsx.withImgAttrs, 'function', 'Expected jsx.withImgAttrs to be a function');
+
+    assert.equal(typeof html.withSourceAttrs, 'function', 'Expected html.withSourceAttrs to be a function');
+    assert.equal(typeof jsx.withSourceAttrs, 'function', 'Expected jsx.withSourceAttrs to be a function');
+
+    return new Response('test success');
+  },
+};

--- a/packages/yoot/tests/cloudflare/wrangler.toml
+++ b/packages/yoot/tests/cloudflare/wrangler.toml
@@ -1,0 +1,4 @@
+name = 'yoot-worker'
+main = "worker.ts"
+compatibility_date = '2025-06-01'
+compatibility_flags = ['nodejs_compat_v2']

--- a/packages/yoot/tests/deno/smoke.test.ts
+++ b/packages/yoot/tests/deno/smoke.test.ts
@@ -1,0 +1,81 @@
+import {describe, it} from 'jsr:@std/testing/bdd';
+import {expect} from 'jsr:@std/expect';
+import {yoot, createAdapter, registerAdapters} from '../../src/index.ts';
+import * as html from '../../src/html.ts';
+import * as jsx from '../../src/jsx.ts';
+
+const IMAGE_URL = 'https://cdn.example.com/file.png';
+
+describe('Deno `yoot` smoke tests', () => {
+  it('should initialize a Yoot object with core methods', () => {
+    expect(typeof yoot).toBe('function');
+
+    const ute = yoot(IMAGE_URL);
+    expect(typeof ute).toBe('function');
+
+    // Test `ute` attributes methods
+    expect(typeof ute.src).toBe('function');
+    expect(typeof ute.alt).toBe('function');
+
+    // Test `ute` directive methods
+    expect(typeof ute.aspectRatio).toBe('function');
+    expect(typeof ute.crop).toBe('function');
+    expect(typeof ute.fit).toBe('function');
+    expect(typeof ute.format).toBe('function');
+    expect(typeof ute.height).toBe('function');
+    expect(typeof ute.h).toBe('function');
+    expect(typeof ute.width).toBe('function');
+    expect(typeof ute.w).toBe('function');
+
+    // Test `ute` output methods
+    expect(typeof ute.toJSON).toBe('function');
+    expect(typeof ute.toString).toBe('function');
+  });
+
+  it('should create and register an adapter', () => {
+    expect(typeof createAdapter).toBe('function');
+    expect(typeof registerAdapters).toBe('function');
+
+    expect(() => {
+      createAdapter({
+        supports: () => true,
+        generateUrl: ({src}) => src,
+      });
+    }).not.toThrow();
+
+    // Create an adapter for further checks
+    const adapter = createAdapter({
+      supports: () => true,
+      generateUrl: ({src}) => src,
+    });
+
+    expect(typeof adapter).toBe('object');
+    expect(adapter).not.toBeNull();
+    expect(typeof adapter.supports).toBe('function');
+    expect(typeof adapter.generateUrl).toBe('function');
+
+    // Verify adapter registration
+    expect(() => registerAdapters(adapter)).not.toThrow();
+    expect(() => registerAdapters()).not.toThrow();
+  });
+
+  it('should have HTML/JSX utilities with expected methods', () => {
+    expect(typeof html.buildSrcSet).toBe('function');
+    expect(typeof jsx.buildSrcSet).toBe('function');
+
+    expect(typeof html.defineSrcSetBuilder).toBe('function');
+    expect(typeof jsx.defineSrcSetBuilder).toBe('function');
+
+    expect(typeof html.getImgAttrs).toBe('function');
+    expect(typeof jsx.getImgAttrs).toBe('function');
+
+    expect(typeof html.getSourceAttrs).toBe('function');
+    expect(typeof jsx.getSourceAttrs).toBe('function');
+
+    expect(typeof html.withImgAttrs).toBe('function');
+    expect(typeof jsx.withImgAttrs).toBe('function');
+
+    expect(typeof html.withSourceAttrs).toBe('function');
+    expect(typeof jsx.withSourceAttrs).toBe('function');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       vitest:
         specifier: ^3.1.4
         version: 3.1.4(@types/debug@4.1.12)(@types/node@22.15.24)(terser@5.39.0)
+      wrangler:
+        specifier: ^4.18.0
+        version: 4.18.0
 
   demo:
     dependencies:
@@ -423,6 +426,53 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
+  '@cloudflare/kv-asset-handler@0.4.0':
+    resolution: {integrity: sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==}
+    engines: {node: '>=18.0.0'}
+
+  '@cloudflare/unenv-preset@2.3.2':
+    resolution: {integrity: sha512-MtUgNl+QkQyhQvv5bbWP+BpBC1N0me4CHHuP2H4ktmOMKdB/6kkz/lo+zqiA4mEazb4y+1cwyNjVrQ2DWeE4mg==}
+    peerDependencies:
+      unenv: 2.0.0-rc.17
+      workerd: ^1.20250508.0
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20250525.0':
+    resolution: {integrity: sha512-L5l+7sSJJT2+riR5rS3Q3PKNNySPjWfRIeaNGMVRi1dPO6QPi4lwuxfRUFNoeUdilZJUVPfSZvTtj9RedsKznQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20250525.0':
+    resolution: {integrity: sha512-Y3IbIdrF/vJWh/WBvshwcSyUh175VAiLRW7963S1dXChrZ1N5wuKGQm9xY69cIGVtitpMJWWW3jLq7J/Xxwm0Q==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20250525.0':
+    resolution: {integrity: sha512-KSyQPAby+c6cpENoO0ayCQlY6QIh28l/+QID7VC1SLXfiNHy+hPNsH1vVBTST6CilHVAQSsy9tCZ9O9XECB8yg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20250525.0':
+    resolution: {integrity: sha512-Nt0FUxS2kQhJUea4hMCNPaetkrAFDhPnNX/ntwcqVlGgnGt75iaAhupWJbU0GB+gIWlKeuClUUnDZqKbicoKyg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20250525.0':
+    resolution: {integrity: sha512-mwTj+9f3uIa4NEXR1cOa82PjLa6dbrb3J+KCVJFYIaq7e63VxEzOchCXS4tublT2pmOhmFqkgBMXrxozxNkR2Q==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@deno/darwin-arm64@2.3.5':
     resolution: {integrity: sha512-aXdxFt/GjVAUlGkqNmmXHPvHUfrOlttWnoHdHm91zxXHvz6Iw5e/uN6huXWcEIb5uXgu43q9KeKFFqNGoRBUpw==}
     cpu: [arm64]
@@ -456,16 +506,34 @@ packages:
   '@emnapi/runtime@1.4.3':
     resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
 
+  '@esbuild/aix-ppc64@0.25.4':
+    resolution: {integrity: sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.5':
     resolution: {integrity: sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.4':
+    resolution: {integrity: sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.5':
     resolution: {integrity: sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.4':
+    resolution: {integrity: sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.5':
@@ -474,16 +542,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.4':
+    resolution: {integrity: sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.5':
     resolution: {integrity: sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.4':
+    resolution: {integrity: sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.5':
     resolution: {integrity: sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.4':
+    resolution: {integrity: sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.5':
@@ -492,10 +578,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.4':
+    resolution: {integrity: sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.5':
     resolution: {integrity: sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.4':
+    resolution: {integrity: sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.5':
@@ -504,10 +602,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.4':
+    resolution: {integrity: sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.5':
     resolution: {integrity: sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.4':
+    resolution: {integrity: sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.5':
@@ -516,10 +626,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.4':
+    resolution: {integrity: sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.5':
     resolution: {integrity: sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.4':
+    resolution: {integrity: sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.5':
@@ -528,10 +650,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.4':
+    resolution: {integrity: sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.5':
     resolution: {integrity: sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.4':
+    resolution: {integrity: sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.5':
@@ -540,10 +674,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.4':
+    resolution: {integrity: sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.5':
     resolution: {integrity: sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.4':
+    resolution: {integrity: sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.25.5':
@@ -552,16 +698,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.4':
+    resolution: {integrity: sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.25.5':
     resolution: {integrity: sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.4':
+    resolution: {integrity: sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.25.5':
     resolution: {integrity: sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.4':
+    resolution: {integrity: sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.25.5':
@@ -570,10 +734,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.4':
+    resolution: {integrity: sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.25.5':
     resolution: {integrity: sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.4':
+    resolution: {integrity: sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.5':
@@ -582,11 +758,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/sunos-x64@0.25.4':
+    resolution: {integrity: sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.5':
     resolution: {integrity: sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.4':
+    resolution: {integrity: sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.5':
     resolution: {integrity: sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==}
@@ -594,10 +782,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.4':
+    resolution: {integrity: sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.5':
     resolution: {integrity: sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.4':
+    resolution: {integrity: sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.5':
@@ -643,6 +843,10 @@ packages:
   '@eslint/plugin-kit@0.3.1':
     resolution: {integrity: sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -797,6 +1001,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -1333,6 +1540,15 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  acorn-walk@8.3.2:
+    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.14.0:
+    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   acorn@8.14.1:
     resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
     engines: {node: '>=0.4.0'}
@@ -1407,6 +1623,9 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  as-table@1.0.55:
+    resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1438,6 +1657,9 @@ packages:
 
   birpc@2.3.0:
     resolution: {integrity: sha512-ijbtkn/F3Pvzb6jHypHRyve2QApOCZDR25D/VnkY2G/lBNcXCTsnsCxgY4k4PkVB7zfwzYbY3O9Lcqe3xufS5g==}
+
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
   blob-to-buffer@1.2.9:
     resolution: {integrity: sha512-BF033y5fN6OCofD3vgHmNtwZWRcq9NLyyxyILx9hfMy1sXYy4ojFl765hJ2lP0YaN2fuxPaLO2Vzzoxy0FLFFA==}
@@ -1579,6 +1801,10 @@ packages:
   cookie-es@1.2.2:
     resolution: {integrity: sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==}
 
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   cookie@1.0.2:
     resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
     engines: {node: '>=18'}
@@ -1608,6 +1834,9 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  data-uri-to-buffer@2.0.2:
+    resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
@@ -1730,6 +1959,11 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
+  esbuild@0.25.4:
+    resolution: {integrity: sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.25.5:
     resolution: {integrity: sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==}
     engines: {node: '>=18'}
@@ -1813,9 +2047,16 @@ packages:
     resolution: {integrity: sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==}
     engines: {node: ^18.19.0 || >=20.5.0}
 
+  exit-hook@2.2.1:
+    resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
+    engines: {node: '>=6'}
+
   expect-type@1.2.1:
     resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
     engines: {node: '>=12.0.0'}
+
+  exsolve@1.0.5:
+    resolution: {integrity: sha512-pz5dvkYYKQ1AHVrgOzBKWeP4u4FRb3a6DNK2ucr0OoNwYIU4QWsJ+NM36LLzORT+z845MzKHHhpXiUF5nvQoJg==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1920,6 +2161,9 @@ packages:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
 
+  get-source@2.0.12:
+    resolution: {integrity: sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==}
+
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
@@ -1934,6 +2178,9 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob-to-regexp@0.4.1:
+    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
@@ -2395,6 +2642,16 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
+  miniflare@4.20250525.0:
+    resolution: {integrity: sha512-F5XRDn9WqxUaHphUT8qwy5WXC/3UwbBRJTdjjP5uwHX82vypxIlHNyHziZnplPLhQa1kbSdIY7wfuP1XJyyYZw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   minimatch@3.0.8:
     resolution: {integrity: sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==}
 
@@ -2422,6 +2679,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -2591,6 +2852,9 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -2641,6 +2905,9 @@ packages:
   pretty-ms@9.2.0:
     resolution: {integrity: sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==}
     engines: {node: '>=18'}
+
+  printable-characters@1.0.42:
+    resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
 
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
@@ -2869,8 +3136,15 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  stacktracey@2.1.8:
+    resolution: {integrity: sha512-Kpij9riA+UNg7TnphqjH7/CzctQ/owJGNbFkfEeve4Z4uxT5+JapVLFXcsurIfN34gnTWZNJ/f7NMG0E8JDzTw==}
+
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+
+  stoppable@1.1.0:
+    resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
+    engines: {node: '>=4', npm: '>=6'}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -3051,6 +3325,13 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
+  unenv@2.0.0-rc.17:
+    resolution: {integrity: sha512-B06u0wXkEd+o5gOCMl/ZHl5cfpYbDZKAT+HWTL+Hws6jWu7dCiqBBXXXzMFcFVJb8D4ytAnYmxJA83uwOQRSsg==}
 
   unicode-properties@1.4.1:
     resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
@@ -3326,6 +3607,21 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  workerd@1.20250525.0:
+    resolution: {integrity: sha512-SXJgLREy/Aqw2J71Oah0Pbu+SShbqbTExjVQyRBTM1r7MG7fS5NUlknhnt6sikjA/t4cO09Bi8OJqHdTkrcnYQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.18.0:
+    resolution: {integrity: sha512-/ng0KI9io97SNsBU1rheADBLLTE5Djybgsi4gXuvH1RBKJGpyj1xWvZ2fuWu8vAonit3EiZkwtERTm6kESHP3A==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20250525.0
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -3337,6 +3633,18 @@ packages:
   wrap-ansi@9.0.0:
     resolution: {integrity: sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==}
     engines: {node: '>=18'}
+
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
@@ -3367,6 +3675,9 @@ packages:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
 
+  youch@3.3.4:
+    resolution: {integrity: sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==}
+
   zimmerframe@1.1.2:
     resolution: {integrity: sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==}
 
@@ -3380,6 +3691,9 @@ packages:
     peerDependencies:
       typescript: ^4.9.4 || ^5.0.2
       zod: ^3
+
+  zod@3.22.3:
+    resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
 
   zod@3.25.32:
     resolution: {integrity: sha512-OSm2xTIRfW8CV5/QKgngwmQW/8aPfGdaQFlrGoErlgg/Epm7cjb6K6VEyExfe65a3VybUOnu381edLb0dfJl0g==}
@@ -3865,6 +4179,35 @@ snapshots:
       human-id: 4.1.1
       prettier: 2.8.8
 
+  '@cloudflare/kv-asset-handler@0.4.0':
+    dependencies:
+      mime: 3.0.0
+
+  '@cloudflare/unenv-preset@2.3.2(unenv@2.0.0-rc.17)(workerd@1.20250525.0)':
+    dependencies:
+      unenv: 2.0.0-rc.17
+    optionalDependencies:
+      workerd: 1.20250525.0
+
+  '@cloudflare/workerd-darwin-64@1.20250525.0':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20250525.0':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20250525.0':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20250525.0':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20250525.0':
+    optional: true
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   '@deno/darwin-arm64@2.3.5':
     optional: true
 
@@ -3888,76 +4231,151 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.4':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.4':
     optional: true
 
   '@esbuild/android-arm64@0.25.5':
     optional: true
 
+  '@esbuild/android-arm@0.25.4':
+    optional: true
+
   '@esbuild/android-arm@0.25.5':
+    optional: true
+
+  '@esbuild/android-x64@0.25.4':
     optional: true
 
   '@esbuild/android-x64@0.25.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.4':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.4':
     optional: true
 
   '@esbuild/darwin-x64@0.25.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.4':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.4':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.4':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.4':
     optional: true
 
   '@esbuild/linux-arm@0.25.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.4':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.4':
     optional: true
 
   '@esbuild/linux-loong64@0.25.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.4':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.4':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.4':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.4':
     optional: true
 
   '@esbuild/linux-s390x@0.25.5':
     optional: true
 
+  '@esbuild/linux-x64@0.25.4':
+    optional: true
+
   '@esbuild/linux-x64@0.25.5':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.4':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.5':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.4':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.5':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.4':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.4':
+    optional: true
+
   '@esbuild/openbsd-x64@0.25.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.4':
     optional: true
 
   '@esbuild/sunos-x64@0.25.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.25.4':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.4':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.4':
     optional: true
 
   '@esbuild/win32-x64@0.25.5':
@@ -4006,6 +4424,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.14.0
       levn: 0.4.1
+
+  '@fastify/busboy@2.1.1': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -4125,6 +4545,11 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@jridgewell/trace-mapping@0.3.25':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -4790,6 +5215,10 @@ snapshots:
     dependencies:
       acorn: 8.14.1
 
+  acorn-walk@8.3.2: {}
+
+  acorn@8.14.0: {}
+
   acorn@8.14.1: {}
 
   ajv-draft-04@1.0.0(ajv@8.13.0):
@@ -4853,6 +5282,10 @@ snapshots:
   array-iterate@2.0.1: {}
 
   array-union@2.1.0: {}
+
+  as-table@1.0.55:
+    dependencies:
+      printable-characters: 1.0.42
 
   assertion-error@2.0.1: {}
 
@@ -4972,6 +5405,8 @@ snapshots:
 
   birpc@2.3.0: {}
 
+  blake3-wasm@2.1.5: {}
+
   blob-to-buffer@1.2.9: {}
 
   boxen@8.0.1:
@@ -5089,13 +5524,11 @@ snapshots:
     dependencies:
       color-name: 1.1.4
       simple-swizzle: 0.2.2
-    optional: true
 
   color@4.2.3:
     dependencies:
       color-convert: 2.0.1
       color-string: 1.9.1
-    optional: true
 
   comma-separated-tokens@2.0.3: {}
 
@@ -5109,6 +5542,8 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie-es@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   cookie@1.0.2: {}
 
@@ -5140,6 +5575,8 @@ snapshots:
   cssesc@3.0.0: {}
 
   csstype@3.1.3: {}
+
+  data-uri-to-buffer@2.0.2: {}
 
   debug@4.4.1:
     dependencies:
@@ -5183,8 +5620,7 @@ snapshots:
 
   detect-indent@6.1.0: {}
 
-  detect-libc@2.0.4:
-    optional: true
+  detect-libc@2.0.4: {}
 
   deterministic-object-hash@2.0.2:
     dependencies:
@@ -5230,6 +5666,34 @@ snapshots:
   error-stack-parser-es@0.1.5: {}
 
   es-module-lexer@1.7.0: {}
+
+  esbuild@0.25.4:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.4
+      '@esbuild/android-arm': 0.25.4
+      '@esbuild/android-arm64': 0.25.4
+      '@esbuild/android-x64': 0.25.4
+      '@esbuild/darwin-arm64': 0.25.4
+      '@esbuild/darwin-x64': 0.25.4
+      '@esbuild/freebsd-arm64': 0.25.4
+      '@esbuild/freebsd-x64': 0.25.4
+      '@esbuild/linux-arm': 0.25.4
+      '@esbuild/linux-arm64': 0.25.4
+      '@esbuild/linux-ia32': 0.25.4
+      '@esbuild/linux-loong64': 0.25.4
+      '@esbuild/linux-mips64el': 0.25.4
+      '@esbuild/linux-ppc64': 0.25.4
+      '@esbuild/linux-riscv64': 0.25.4
+      '@esbuild/linux-s390x': 0.25.4
+      '@esbuild/linux-x64': 0.25.4
+      '@esbuild/netbsd-arm64': 0.25.4
+      '@esbuild/netbsd-x64': 0.25.4
+      '@esbuild/openbsd-arm64': 0.25.4
+      '@esbuild/openbsd-x64': 0.25.4
+      '@esbuild/sunos-x64': 0.25.4
+      '@esbuild/win32-arm64': 0.25.4
+      '@esbuild/win32-ia32': 0.25.4
+      '@esbuild/win32-x64': 0.25.4
 
   esbuild@0.25.5:
     optionalDependencies:
@@ -5363,7 +5827,11 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.1
 
+  exit-hook@2.2.1: {}
+
   expect-type@1.2.1: {}
+
+  exsolve@1.0.5: {}
 
   extend@3.0.2: {}
 
@@ -5477,6 +5945,11 @@ snapshots:
 
   get-east-asian-width@1.3.0: {}
 
+  get-source@2.0.12:
+    dependencies:
+      data-uri-to-buffer: 2.0.2
+      source-map: 0.6.1
+
   get-stream@9.0.1:
     dependencies:
       '@sec-ant/readable-stream': 0.4.1
@@ -5491,6 +5964,8 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob-to-regexp@0.4.1: {}
 
   glob@10.4.5:
     dependencies:
@@ -5660,8 +6135,7 @@ snapshots:
 
   iron-webcrypto@1.2.1: {}
 
-  is-arrayish@0.3.2:
-    optional: true
+  is-arrayish@0.3.2: {}
 
   is-core-module@2.16.1:
     dependencies:
@@ -6165,6 +6639,26 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime@3.0.0: {}
+
+  miniflare@4.20250525.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      acorn: 8.14.0
+      acorn-walk: 8.3.2
+      exit-hook: 2.2.1
+      glob-to-regexp: 0.4.1
+      sharp: 0.33.5
+      stoppable: 1.1.0
+      undici: 5.29.0
+      workerd: 1.20250525.0
+      ws: 8.18.0
+      youch: 3.3.4
+      zod: 3.22.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimatch@3.0.8:
     dependencies:
       brace-expansion: 1.1.11
@@ -6186,6 +6680,8 @@ snapshots:
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
+
+  mustache@4.2.0: {}
 
   nanoid@3.3.11: {}
 
@@ -6341,6 +6837,8 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
+  path-to-regexp@6.3.0: {}
+
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
@@ -6372,6 +6870,8 @@ snapshots:
   pretty-ms@9.2.0:
     dependencies:
       parse-ms: 4.0.0
+
+  printable-characters@1.0.42: {}
 
   prismjs@1.30.0: {}
 
@@ -6600,7 +7100,6 @@ snapshots:
       '@img/sharp-wasm32': 0.33.5
       '@img/sharp-win32-ia32': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -6626,7 +7125,6 @@ snapshots:
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
-    optional: true
 
   sirv@3.0.1:
     dependencies:
@@ -6663,7 +7161,14 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  stacktracey@2.1.8:
+    dependencies:
+      as-table: 1.0.55
+      get-source: 2.0.12
+
   std-env@3.9.0: {}
+
+  stoppable@1.1.0: {}
 
   string-argv@0.3.2: {}
 
@@ -6828,6 +7333,18 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@6.21.0: {}
+
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
+  unenv@2.0.0-rc.17:
+    dependencies:
+      defu: 6.1.4
+      exsolve: 1.0.5
+      ohash: 2.0.11
+      pathe: 2.0.3
+      ufo: 1.6.1
 
   unicode-properties@1.4.1:
     dependencies:
@@ -7103,6 +7620,30 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  workerd@1.20250525.0:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20250525.0
+      '@cloudflare/workerd-darwin-arm64': 1.20250525.0
+      '@cloudflare/workerd-linux-64': 1.20250525.0
+      '@cloudflare/workerd-linux-arm64': 1.20250525.0
+      '@cloudflare/workerd-windows-64': 1.20250525.0
+
+  wrangler@4.18.0:
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.0
+      '@cloudflare/unenv-preset': 2.3.2(unenv@2.0.0-rc.17)(workerd@1.20250525.0)
+      blake3-wasm: 2.1.5
+      esbuild: 0.25.4
+      miniflare: 4.20250525.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.17
+      workerd: 1.20250525.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -7120,6 +7661,8 @@ snapshots:
       ansi-styles: 6.2.1
       string-width: 7.2.0
       strip-ansi: 7.1.0
+
+  ws@8.18.0: {}
 
   xxhash-wasm@1.1.0: {}
 
@@ -7139,6 +7682,12 @@ snapshots:
 
   yoctocolors@2.1.1: {}
 
+  youch@3.3.4:
+    dependencies:
+      cookie: 0.7.2
+      mustache: 4.2.0
+      stacktracey: 2.1.8
+
   zimmerframe@1.1.2: {}
 
   zod-to-json-schema@3.24.5(zod@3.25.32):
@@ -7149,6 +7698,8 @@ snapshots:
     dependencies:
       typescript: 5.8.3
       zod: 3.25.32
+
+  zod@3.22.3: {}
 
   zod@3.25.32: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.1.4
         version: 3.1.4(vitest@3.1.4(@types/debug@4.1.12)(@types/node@22.15.24)(terser@5.39.0))
+      bun:
+        specifier: ^1.2.15
+        version: 1.2.15
       deno:
         specifier: ^2.3.5
         version: 2.3.5
@@ -845,6 +848,61 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
+  '@oven/bun-darwin-aarch64@1.2.15':
+    resolution: {integrity: sha512-DE2iO1xF6dTKBqHbRD/g9FxzuhbtVHnbSMV6KvvikYBRvteNJqV7I/FzoDXgbR3rRne3DF+gnCQO8T17tIfErw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oven/bun-darwin-x64-baseline@1.2.15':
+    resolution: {integrity: sha512-is6NrxFkT2WGffPyw0wQQeJ8Jztm115Y/hKsVtXySkF+GqUYEWqK2pzpsEDxhhOELBmxK9uUOkiOvPBZL4A2uQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oven/bun-darwin-x64@1.2.15':
+    resolution: {integrity: sha512-yRjJ0ELTlpSYCRi9buJDUAZ5TAv8GKT/lJ0Bemmed8RNEtETfLMNUmjQqts2aXRX1M7VIBvUiiHrSFHvhrfZ8A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oven/bun-linux-aarch64-musl@1.2.15':
+    resolution: {integrity: sha512-CryplmxMcePF25vYq5C32jAO0qK4hLcGCXRUArPvrfFldixzppCQpKIBp4FvV2wA3fF66enckV0EPvGWofQA5g==}
+    cpu: [aarch64]
+    os: [linux]
+
+  '@oven/bun-linux-aarch64@1.2.15':
+    resolution: {integrity: sha512-L+TitZk5s60ipBGuPvNJ+oM7d6JC7gejGCmEZcUvdKf3dXG1k0E/Yr1Ox4j75U7VRV7tIRBnkis6BBBCMzdLmA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oven/bun-linux-x64-baseline@1.2.15':
+    resolution: {integrity: sha512-RRGDCE3WcFrJUCwe1rPbaNANWR65BgaA2i79R1FFPaPw8mWoUhuYBcokRpeP4usevNtv/vWOfh3p05X3OczOpQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oven/bun-linux-x64-musl-baseline@1.2.15':
+    resolution: {integrity: sha512-Z53su6s5d5l75dnkiytBwJxWCTB5/LpXH3GWGtrCn8hR5QzstNzdt1b7J//WGGaVmRdcdr5RKk+hw9NRVrCjeA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oven/bun-linux-x64-musl@1.2.15':
+    resolution: {integrity: sha512-M/fJA7jj+D3FA5PnpXwv43lGjY34xTQaaAV7RvAS7AW20eyGLyqVk3pW8peHG3IBQdWhblYzVNHn872lu3wn5A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oven/bun-linux-x64@1.2.15':
+    resolution: {integrity: sha512-U5gwBEVH/f+MvjZZyqwY/gIdbAjho9s1g3w7PQoB0cwaGrpY0zEkwHkYvqVriU0FPxN6VjZycBpePd3X6LrX0Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oven/bun-windows-x64-baseline@1.2.15':
+    resolution: {integrity: sha512-4Bgf6Xh+bh0n1YYJLRZdZuQXBLGDJDFASpyP3nP72D5/gm71kmlujuM6gPPmbyjxu7FOmP2x5gGEfQ6ydk68CA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oven/bun-windows-x64@1.2.15':
+    resolution: {integrity: sha512-Ya4pTRtbuuoXHNKRCONuIqHk9fMME7LUWDNbig/jV08IF3fn3epMOqg716Ik2DTiYOX5Q+9O82+mz8hEFE9StA==}
+    cpu: [x64]
+    os: [win32]
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1408,6 +1466,12 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  bun@1.2.15:
+    resolution: {integrity: sha512-9Nryct8QYQRE/W3/FjW2i4eLdVKme7JPY8R9DNLSGjKdSX8uMgZ2mogs+H5d88Ng0bYeSLpUkBhRelbNi8MwYA==}
+    cpu: [arm64, x64, aarch64]
+    os: [darwin, linux, win32]
+    hasBin: true
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -4157,6 +4221,39 @@ snapshots:
 
   '@oslojs/encoding@1.1.0': {}
 
+  '@oven/bun-darwin-aarch64@1.2.15':
+    optional: true
+
+  '@oven/bun-darwin-x64-baseline@1.2.15':
+    optional: true
+
+  '@oven/bun-darwin-x64@1.2.15':
+    optional: true
+
+  '@oven/bun-linux-aarch64-musl@1.2.15':
+    optional: true
+
+  '@oven/bun-linux-aarch64@1.2.15':
+    optional: true
+
+  '@oven/bun-linux-x64-baseline@1.2.15':
+    optional: true
+
+  '@oven/bun-linux-x64-musl-baseline@1.2.15':
+    optional: true
+
+  '@oven/bun-linux-x64-musl@1.2.15':
+    optional: true
+
+  '@oven/bun-linux-x64@1.2.15':
+    optional: true
+
+  '@oven/bun-windows-x64-baseline@1.2.15':
+    optional: true
+
+  '@oven/bun-windows-x64@1.2.15':
+    optional: true
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -4914,6 +5011,20 @@ snapshots:
 
   buffer-from@1.1.2:
     optional: true
+
+  bun@1.2.15:
+    optionalDependencies:
+      '@oven/bun-darwin-aarch64': 1.2.15
+      '@oven/bun-darwin-x64': 1.2.15
+      '@oven/bun-darwin-x64-baseline': 1.2.15
+      '@oven/bun-linux-aarch64': 1.2.15
+      '@oven/bun-linux-aarch64-musl': 1.2.15
+      '@oven/bun-linux-x64': 1.2.15
+      '@oven/bun-linux-x64-baseline': 1.2.15
+      '@oven/bun-linux-x64-musl': 1.2.15
+      '@oven/bun-linux-x64-musl-baseline': 1.2.15
+      '@oven/bun-windows-x64': 1.2.15
+      '@oven/bun-windows-x64-baseline': 1.2.15
 
   bundle-name@4.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.1.4
         version: 3.1.4(vitest@3.1.4(@types/debug@4.1.12)(@types/node@22.15.24)(terser@5.39.0))
+      deno:
+        specifier: ^2.3.5
+        version: 2.3.5
       eslint:
         specifier: ^9.27.0
         version: 9.27.0
@@ -416,6 +419,36 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@deno/darwin-arm64@2.3.5':
+    resolution: {integrity: sha512-aXdxFt/GjVAUlGkqNmmXHPvHUfrOlttWnoHdHm91zxXHvz6Iw5e/uN6huXWcEIb5uXgu43q9KeKFFqNGoRBUpw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@deno/darwin-x64@2.3.5':
+    resolution: {integrity: sha512-0APfmYq+988sTb+Pp9ot+JZqrYHjJdqrF3U3j+8zZszxD4UgjpXmnO7wuvrO4rFvFktByNKk2Qvmq0aAtMUd8A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@deno/linux-arm64-glibc@2.3.5':
+    resolution: {integrity: sha512-NE3Ntkf+7X75UfLREVHjLm2wLdeTAt34I8secI8+MLmtiWGtRcJqihnm81SsF3objOLHFDFIeSIT9DHSD2IjDw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@deno/linux-x64-glibc@2.3.5':
+    resolution: {integrity: sha512-IQ0QBAEw+3LxLtlU8mxYQw7N8NhTSBClFGGUCjqTA3g+mFdecVH8TAlkm/p44galVohrUZmIo211HqY2InZnMQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@deno/win32-arm64@2.3.5':
+    resolution: {integrity: sha512-HPuUSGtHlMuv26Ug4yR77KsLDVvzrZumy49ge/e17kQtAdGC07j5n5vawsviNKLttGqFFonkEPr0vquhq+2+Cw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@deno/win32-x64@2.3.5':
+    resolution: {integrity: sha512-KCF6Yp0y8Sy2f5TXIzLh3P0MvlhI6KanIFqt60+RQJfdklTmGmMGfrW7cC4OYSKHOKJaOPjdQce3HNL3DcycvA==}
+    cpu: [x64]
+    os: [win32]
 
   '@emnapi/runtime@1.4.3':
     resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
@@ -1552,6 +1585,10 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  deno@2.3.5:
+    resolution: {integrity: sha512-4nGPpug2LmZ3kTinnkbiSUmoqSYmerTTjr2OxKw4xrno5W4ILR1dfmVpDsQN8oecT9mEUw+3r/xamdiRNcKBog==}
+    hasBin: true
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -3764,6 +3801,24 @@ snapshots:
       human-id: 4.1.1
       prettier: 2.8.8
 
+  '@deno/darwin-arm64@2.3.5':
+    optional: true
+
+  '@deno/darwin-x64@2.3.5':
+    optional: true
+
+  '@deno/linux-arm64-glibc@2.3.5':
+    optional: true
+
+  '@deno/linux-x64-glibc@2.3.5':
+    optional: true
+
+  '@deno/win32-arm64@2.3.5':
+    optional: true
+
+  '@deno/win32-x64@2.3.5':
+    optional: true
+
   '@emnapi/runtime@1.4.3':
     dependencies:
       tslib: 2.8.1
@@ -5001,6 +5056,15 @@ snapshots:
   define-lazy-prop@3.0.0: {}
 
   defu@6.1.4: {}
+
+  deno@2.3.5:
+    optionalDependencies:
+      '@deno/darwin-arm64': 2.3.5
+      '@deno/darwin-x64': 2.3.5
+      '@deno/linux-arm64-glibc': 2.3.5
+      '@deno/linux-x64-glibc': 2.3.5
+      '@deno/win32-arm64': 2.3.5
+      '@deno/win32-x64': 2.3.5
 
   dequal@2.0.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 packages:
   - demo
   - packages/**
-
 onlyBuiltDependencies:
+  - deno
   - esbuild
   - sharp

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ onlyBuiltDependencies:
   - deno
   - esbuild
   - sharp
+  - workerd

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - demo
   - packages/**
 onlyBuiltDependencies:
+  - bun
   - deno
   - esbuild
   - sharp

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,7 @@
     "moduleDetection": "force",
     // Bundler behavior
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,
     // Safety & strictness

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
   },
   test: {
     include: ['**/*.test.ts'],
-    exclude: ['node_modules', '**/tests/deno/**'],
+    exclude: ['node_modules', '**/tests/bun/**', '**/tests/deno/**'],
     setupFiles: [path.resolve(__dirname, 'vitest.setup.ts')],
     chaiConfig: {
       truncateThreshold: 0,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
   },
   test: {
     include: ['**/*.test.ts'],
-    exclude: ['node_modules'],
+    exclude: ['node_modules', '**/tests/deno/**'],
     setupFiles: [path.resolve(__dirname, 'vitest.setup.ts')],
     chaiConfig: {
       truncateThreshold: 0,


### PR DESCRIPTION
This PR adds smoke test coverage and unifies test execution across all runtimes:

- Added smoke tests for Bun, Deno, and Cloudflare.
- Updated scripts and configurations for each runtime.
- Refactored the root `test` script to run all package tests with concurrency 1, addressing Cloudflare smoke test conflicts.
- Merged package-level `test` scripts to support Node (including Cloudflare), Deno, and Bun.
- Exported `afterAll` and `afterEach` lifecycle hooks from test-kit for greater flexibility.

These updates have been tested locally and improve reliability across environments.