### PR TITLE
chore(changesets): set commitMode to github-api for GitHub API commits

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,6 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/changelog-git",
   "commit": false,
+  "commitMode": "github-api",
   "fixed": [],
   "linked": [],
   "access": "public",


### PR DESCRIPTION
This PR updates Changesets config to use `commitMode: github-api` for commits via GitHub API, improving commit attribution.