### PR TITLE
fix(docs): apply module-level JSDoc comments for better clarity

### DIFF
--- a/.changeset/orange-lands-ring.md
+++ b/.changeset/orange-lands-ring.md
@@ -1,0 +1,9 @@
+---
+'@yoot/cloudinary': patch
+'@yoot/shopify': patch
+'@yoot/sanity': patch
+'@yoot/imgix': patch
+'@yoot/yoot': patch
+---
+
+Applied module-level JSDoc annotations across all public packages for better clarity and JSR compatibility.

--- a/packages/adapters/cloudinary/src/core/adapter.ts
+++ b/packages/adapters/cloudinary/src/core/adapter.ts
@@ -1,3 +1,8 @@
+/**
+ * Cloudinary adapter implementation for Yoot.
+ * @remarks Handles Cloudinary CDN URLs and applies transformation directives via path segments.
+ * @module
+ */
 import {createAdapter} from '@yoot/yoot';
 import type {Adapter, DirectiveNames, Directives, GenerateUrlInput} from '@yoot/yoot';
 import {_isKeyOf as isKeyOf, _isEmpty as isEmpty} from '@yoot/yoot/internal';

--- a/packages/adapters/cloudinary/src/index.ts
+++ b/packages/adapters/cloudinary/src/index.ts
@@ -1,1 +1,18 @@
+/**
+ * Cloudinary adapter entry for Yoot, exported as both a `default` and a `named` export.
+ *
+ * @module @yoot/cloudinary
+ * @packageDocumentation
+ * @public
+ *
+ * @example Default import
+ * ```ts
+ * import cloudinary from '@yoot/cloudinary';
+ * ```
+ *
+ * @example Named import
+ * ```ts
+ * import {cloudinaryAdapter} from '@yoot/cloudinary';
+ * ```
+ */
 export {adapter as cloudinaryAdapter, adapter as default} from './core/adapter.ts';

--- a/packages/adapters/cloudinary/src/register.ts
+++ b/packages/adapters/cloudinary/src/register.ts
@@ -1,9 +1,19 @@
+/**
+ * Automatically registers the Cloudinary adapter with Yoot at runtime.
+ *
+ * @module @yoot/cloudinary/register
+ * @packageDocumentation
+ * @public
+ *
+ * @example
+ * ```ts
+ * import '@yoot/cloudinary/register';
+ * ```
+ */
 import {registerAdapters} from '@yoot/yoot';
 import {adapter} from './core/adapter.ts';
-/**
- * Automatic adapter registration for the Cloudinary adapter.
- * @packageDocumentation
- */
+
+/** Empty export to ensure this file is treated as a module */
 export {};
 
 registerAdapters(adapter);

--- a/packages/adapters/imgix/src/core/adapter.ts
+++ b/packages/adapters/imgix/src/core/adapter.ts
@@ -1,3 +1,8 @@
+/**
+ * Imgix adapter implementation for Yoot.
+ * @remarks Handles Imgix CDN URLs and applies transformation directives via query parameters.
+ * @module
+ */
 import {createAdapter} from '@yoot/yoot';
 import type {Adapter, DirectiveNames, Directives, GenerateUrlInput} from '@yoot/yoot';
 import {_isKeyOf as isKeyOf, _isEmpty as isEmpty} from '@yoot/yoot/internal';

--- a/packages/adapters/imgix/src/index.ts
+++ b/packages/adapters/imgix/src/index.ts
@@ -1,1 +1,18 @@
+/**
+ * Imgix adapter entry for Yoot, exported as both a `default` and a `named` export.
+ *
+ * @module @yoot/imgix
+ * @packageDocumentation
+ * @public
+ *
+ * @example Default import
+ * ```ts
+ * import imgix from '@yoot/imgix';
+ * ```
+ *
+ * @example Named import
+ * ```ts
+ * import {imgixAdapter} from '@yoot/imgix';
+ * ```
+ */
 export {adapter as imgixAdapter, adapter as default} from './core/adapter.ts';

--- a/packages/adapters/imgix/src/register.ts
+++ b/packages/adapters/imgix/src/register.ts
@@ -1,6 +1,19 @@
+/**
+ * Automatically registers the Imgix adapter with Yoot at runtime.
+ *
+ * @module @yoot/imgix/register
+ * @packageDocumentation
+ * @public
+ *
+ * @example
+ * ```ts
+ * import '@yoot/imgix/register';
+ * ```
+ */
 import {registerAdapters} from '@yoot/yoot';
 import {adapter} from './core/adapter.ts';
 
+/** Empty export to ensure this file is treated as a module */
 export {};
 
 registerAdapters(adapter);

--- a/packages/adapters/sanity/src/core/adapter.ts
+++ b/packages/adapters/sanity/src/core/adapter.ts
@@ -1,3 +1,8 @@
+/**
+ * Sanity adapter implementation for Yoot.
+ * @remarks Handles Sanity CDN URLs and applies transformation directives via query parameters.
+ * @module
+ */
 import {createAdapter} from '@yoot/yoot';
 import type {Adapter, DirectiveNames, Directives, GenerateUrlInput, YootState, PrimeStateInput} from '@yoot/yoot';
 import {

--- a/packages/adapters/sanity/src/index.ts
+++ b/packages/adapters/sanity/src/index.ts
@@ -1,1 +1,18 @@
+/**
+ * Sanity adapter entry for Yoot, exported as both a `default` and a `named` export.
+ *
+ * @module @yoot/sanity
+ * @packageDocumentation
+ * @public
+ *
+ * @example Default import
+ * ```ts
+ * import sanity from '@yoot/sanity';
+ * ```
+ *
+ * @example Named import
+ * ```ts
+ * import {sanityAdapter} from '@yoot/sanity';
+ * ```
+ */
 export {adapter as sanityAdapter, adapter as default} from './core/adapter.ts';

--- a/packages/adapters/sanity/src/register.ts
+++ b/packages/adapters/sanity/src/register.ts
@@ -1,6 +1,19 @@
+/**
+ * Automatically registers the Sanity adapter with Yoot at runtime.
+ *
+ * @module @yoot/sanity/register
+ * @packageDocumentation
+ * @public
+ *
+ * @example
+ * ```ts
+ * import '@yoot/sanity/register';
+ * ```
+ */
 import {registerAdapters} from '@yoot/yoot';
 import {adapter} from './core/adapter.ts';
 
+/** Empty export to ensure this file is treated as a module */
 export {};
 
 registerAdapters(adapter);

--- a/packages/adapters/shopify/src/core/adapter.ts
+++ b/packages/adapters/shopify/src/core/adapter.ts
@@ -1,3 +1,8 @@
+/**
+ * Shopify adapter implementation for Yoot.
+ * @remarks Handles Shopify CDN URLs and applies transformation directives via path segments.
+ * @module
+ */
 import {createAdapter} from '@yoot/yoot';
 import type {Adapter, Directives, GenerateUrlInput, YootState, PrimeStateInput} from '@yoot/yoot';
 import {_isEmpty as isEmpty, _isNumber as isNumber} from '@yoot/yoot/internal';

--- a/packages/adapters/shopify/src/index.ts
+++ b/packages/adapters/shopify/src/index.ts
@@ -1,1 +1,18 @@
+/**
+ * Shopify adapter entry for Yoot, exported as both a `default` and a `named` export.
+ *
+ * @module @yoot/shopify
+ * @packageDocumentation
+ * @public
+ *
+ * @example Default import
+ * ```ts
+ * import shopify from '@yoot/shopify';
+ * ```
+ *
+ * @example Named import
+ * ```ts
+ * import {shopifyAdapter} from '@yoot/shopify';
+ * ```
+ */
 export {adapter as shopifyAdapter, adapter as default} from './core/adapter.ts';

--- a/packages/adapters/shopify/src/register.ts
+++ b/packages/adapters/shopify/src/register.ts
@@ -1,6 +1,19 @@
+/**
+ * Automatically registers the Shopify adapter with Yoot at runtime.
+ *
+ * @module @yoot/shopify/register
+ * @packageDocumentation
+ * @public
+ *
+ * @example
+ * ```ts
+ * import '@yoot/shopify/register';
+ * ```
+ */
 import {registerAdapters} from '@yoot/yoot';
 import {adapter} from './core/adapter.ts';
 
+/** Empty export to ensure this file is treated as a module */
 export {};
 
 registerAdapters(adapter);

--- a/packages/yoot/src/html.ts
+++ b/packages/yoot/src/html.ts
@@ -1,1 +1,7 @@
+/**
+ * HTML helpers for Yoot that generate attributes tailored for HTML-style syntax environments, e.g. Astro and Svelte.
+ * @module @yoot/yoot/html
+ * @packageDocumentation
+ * @public
+ */
 export * from './core/html.ts';

--- a/packages/yoot/src/index.ts
+++ b/packages/yoot/src/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Core library for Yoot, exporting `yoot`, adapter utilities, and configuration helpers.
+ * @module @yoot/yoot
+ * @packageDocumentation
+ * @public
+ */
 export {yoot} from './core/yoot.ts';
 export type * from './core/yoot.ts';
 

--- a/packages/yoot/src/internal.ts
+++ b/packages/yoot/src/internal.ts
@@ -1,7 +1,11 @@
-// 🚨 INTERNAL API: DO NOT USE IN APPLICATION CODE
-// This module is intended for use only by @yoot/* adapter packages.
-// It is not part of the public API, may change without notice, and is unsupported.
-// All exports are prefixed with `_` to signal their internal status.
+/**
+ * 🚨 INTERNAL API: DO NOT USE IN APPLICATION CODE
+ * @remarks This module is strictly for internal use by `@yoot/*` adapter packages.
+ * It is not part of the public API and may change or be removed without notice.
+ * @module @yoot/yoot/internal
+ * @packageDocumentation
+ * @internal
+ */
 export {
   hasIntrinsicDimensions as _hasIntrinsicDimensions,
   isKeyOf as _isKeyOf,

--- a/packages/yoot/src/jsx.ts
+++ b/packages/yoot/src/jsx.ts
@@ -1,3 +1,9 @@
+/**
+ * JSX helpers for Yoot that generate attributes tailored for JSX-style syntax environments, e.g. React and Solid.
+ * @module @yoot/yoot/jsx
+ * @packageDocumentation
+ * @public
+ */
 export {
   buildSrcSet,
   defineSrcSetBuilder,


### PR DESCRIPTION
This PR applies consistent module-level JSDoc comments across all public packages. These updates enhance documentation clarity and improve compatibility with JSR. The changes are purely documentation-focused and do not impact runtime behavior.

Updated documentation for all public packages: `@yoot/cloudinary`, `@yoot/imgix`, `@yoot/sanity`, `@yoot/shopify`, and `@yoot/yoot`.

### Key Changes

- Added module-level documentation to all entry points.
- Added module-level documentation specifically to the `core/adapter.ts` file in all adapter packages.
- Added `@example` annotations demonstrating usage in all adapter packages' entry points.