### PR TITLE
fix: add ISC license to deno.json files for public packages

### DIFF
--- a/.changeset/green-berries-divide.md
+++ b/.changeset/green-berries-divide.md
@@ -1,0 +1,9 @@
+---
+'@yoot/cloudinary': patch
+'@yoot/shopify': patch
+'@yoot/sanity': patch
+'@yoot/imgix': patch
+'@yoot/yoot': patch
+---
+
+Added ISC license to `deno.json` files for public packages.

--- a/packages/adapters/cloudinary/deno.json
+++ b/packages/adapters/cloudinary/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@yoot/cloudinary",
   "version": "0.2.1",
+  "license": "ISC",
   "exports": {
     ".": "./src/index.ts",
     "./register": "./src/register.ts"

--- a/packages/adapters/imgix/deno.json
+++ b/packages/adapters/imgix/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@yoot/imgix",
   "version": "0.2.1",
+  "license": "ISC",
   "exports": {
     ".": "./src/index.ts",
     "./register": "./src/register.ts"

--- a/packages/adapters/sanity/deno.json
+++ b/packages/adapters/sanity/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@yoot/sanity",
   "version": "0.2.1",
+  "license": "ISC",
   "exports": {
     ".": "./src/index.ts",
     "./register": "./src/register.ts"

--- a/packages/adapters/shopify/deno.json
+++ b/packages/adapters/shopify/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@yoot/shopify",
   "version": "0.2.1",
+  "license": "ISC",
   "exports": {
     ".": "./src/index.ts",
     "./register": "./src/register.ts"

--- a/packages/yoot/deno.json
+++ b/packages/yoot/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@yoot/yoot",
   "version": "0.2.1",
+  "license": "ISC",
   "exports": {
     ".": "./src/index.ts",
     "./html": "./src/html.ts",


### PR DESCRIPTION
This PR adds the ISC license to the `deno.json` files for all public packages. Including this license field ensures clarity and aligns with the related `package.json` files.