### PR TITLE
chore(demo): add configuration for stackblitz and codesandbox, update readme

### DIFF
--- a/demo/.codesandbox/tasks.json
+++ b/demo/.codesandbox/tasks.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://codesandbox.io/schemas/tasks.json",
+  "setupTasks": [
+    {
+      "name": "Installing Dependencies",
+      "command": "pnpm add @yoot/yoot@latest @yoot/cloudinary@latest @yoot/imgix@latest @yoot/sanity@latest @yoot/shopify@latest"
+    }
+  ],
+  "tasks": {
+    "run-dev": {
+      "name": "Demo App",
+      "command": "pnpm dev",
+      "runAtStart": true
+    }
+  }
+}

--- a/demo/.devcontainer/devcontainer.json
+++ b/demo/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "@yoot demo",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:22",
+  "features": {
+    "ghcr.io/devcontainers-extra/features/pnpm:2": {
+      "version": "10.11.0"
+    }
+  }
+}

--- a/demo/.stackblitzrc
+++ b/demo/.stackblitzrc
@@ -1,0 +1,4 @@
+{
+  "installDependencies": false,
+  "startCommand": "pnpm add @yoot/yoot@latest @yoot/cloudinary@latest @yoot/imgix@latest @yoot/sanity@latest @yoot/shopify@latest && pnpm dev"
+}

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,47 +1,94 @@
-# Astro Starter Kit: Minimal
+<div align="center" style="display:grid;row-gap:0.5rem">
 
-```sh
-bun create astro@latest -- --template minimal
-```
+<h1>Yoot Demo</h1>
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/minimal)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/minimal)
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/minimal/devcontainer.json)
+<p style="font-size:1.25rem;opacity:0.6">
+  <strong>One API. Any CDN. Full control.</strong>
+</p>
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+<p style="max-width:70ch;margin-inline:auto">
+    This demo showcases the core functionality of <code>yoot</code>, illustrating its use with various CDN adapters and frontend components within an Astro application.
+</p>
 
-## 🚀 Project Structure
+<div style="max-width:80ch;margin-inline:auto">
+  <img src="https://img.shields.io/badge/Built%20with-Astro-ff5a0d?style=flat-square&logo=astro" alt="Built with Astro" />
+  <a href="https://github.com/theisel/yoot/blob/main/packages/yoot">
+    <img src="https://img.shields.io/badge/Core%20library-@yoot/yoot-deeppink?style=flat-square" alt="Yoot Core Library" />
+  </a>
+</div>
 
-Inside of your Astro project, you'll see the following folders and files:
+</div>
 
-```text
-/
-├── public/
-├── src/
-│   └── pages/
-│       └── index.astro
-└── package.json
-```
+---
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+> **TL;DR:** This demo provides practical examples of `yoot`'s image transformation capabilities across multiple CDNs (Cloudinary, Imgix, Sanity, Shopify) and UI frameworks (React, Svelte, Solid, Vue).
 
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
+---
 
-Any static assets, like images, can be placed in the `public/` directory.
+&nbsp;
 
-## 🧞 Commands
+## About
 
-All commands are run from the root of the project, from a terminal:
+This application serves as a practical showcase for the [`yoot`](https://github.com/theisel/yoot) library and its adapters. The goal is to provide a clear, hands-on understanding of `yoot` in real-world scenarios. It demonstrates:
 
-| Command               | Action                                           |
-| :-------------------- | :----------------------------------------------- |
-| `bun install`         | Installs dependencies                            |
-| `bun dev`             | Starts local dev server at `localhost:4321`      |
-| `bun build`           | Build your production site to `./dist/`          |
-| `bun preview`         | Preview your build locally, before deploying     |
-| `bun astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `bun astro -- --help` | Get help using the Astro CLI                     |
+- **Adapter integration:** Registering CDN adapters.
+- **Preset usage:** Defining and applying reusable transformation sets.
+- **Core transformations:** Common image operations like resizing and fitting.
+- **Multi-framework rendering:** Using `yoot` with React, Svelte, Solid, and Vue components within an Astro project.
 
-## 👀 Want to learn more?
+&nbsp;
 
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+## Showcasing
+
+Key `yoot` features highlighted:
+
+- **CDN Adapters:**
+  - `@yoot/cloudinary`
+  - `@yoot/imgix`
+  - `@yoot/sanity`
+  - `@yoot/shopify`
+- **Transformation Presets:** For `square`, `landscape`, and `portrait` aspects.
+- **Fit Modes:** Comparison of `fit('cover')` vs. `fit('contain')`.
+- **API Usage:** `yoot` initialization, chaining methods, and preset application.
+
+&nbsp;
+
+## Running locally
+
+To run the demo locally:
+
+1. **Clone the repository:**
+   ```bash
+   git clone https://github.com/theisel/yoot.git
+   cd yoot
+   ```
+2. **Install dependencies** (from root):
+   ```bash
+   pnpm install
+   ```
+3. **Launch the demo:**
+   ```bash
+   pnpm demo:launch
+   ```
+   > This runs the app in dev mode. Open your browser to the URL provided in the terminal.
+
+&nbsp;
+
+## Demo
+
+Try it live — zero setup:
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/theisel/yoot/tree/main/demo)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/theisel/yoot/tree/main/demo)
+
+&nbsp;
+
+## Contributing
+
+Found a bug or wish to contribute? [Open an issue](https://github.com/theisel/yoot/issues) or [send a PR](https://github.com/theisel/yoot/blob/main/CONTRIBUTING.md).
+
+&nbsp;
+
+## License
+
+Licensed under the ISC License.


### PR DESCRIPTION
This PR enhances the DX by adding pre-configured setups for StackBlitz and CodeSandbox. It also updates the README to include an overview of the demo app.

### Key Changes

- **StackBlitz:** Adds a `.stackblitzrc` file for easy setup.
- **CodeSandbox:** Includes `.devcontainer` and `.codesandbox` configurations.
- **Documentation:** Updates the README with an overview of the demo app.