### PR TITLE
chore: bump Node to v24 and pnpm to latest; improve scripts and update shebang

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,10 @@
 {
   "name": "@yoot development",
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:22",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24",
   "features": {
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers-extra/features/pnpm:2": {
-      "version": "10.11.0"
+      "version": "10.12.1"
     }
   },
   // Configure tool-specific properties.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,8 +10,8 @@ permissions:
   contents: write
 
 env:
-  NODE_VERSION: '22'
-  PNPM_VERSION: '10.11.0'
+  NODE_VERSION: 24
+  PNPM_VERSION: 10.12.1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,8 +14,8 @@ permissions:
   contents: write
 
 env:
-  NODE_VERSION: '22'
-  PNPM_VERSION: '10.11.0'
+  NODE_VERSION: 24
+  PNPM_VERSION: 10.12.1
 
 jobs:
   format:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ permissions:
 
 env:
   NPM_CONFIG_PROVENANCE: true
-  NODE_VERSION: '22'
-  PNPM_VERSION: '10.11.0'
+  NODE_VERSION: 24
+  PNPM_VERSION: 10.12.1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "wrangler": "^4.18.0",
     "zx": "^8.5.5"
   },
-  "packageManager": "pnpm@10.11.0",
+  "packageManager": "pnpm@10.12.1",
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   }
 }

--- a/scripts/build-postprocess.js
+++ b/scripts/build-postprocess.js
@@ -1,4 +1,5 @@
-#!/usr/bin/env zx
+#!/usr/bin/env node
+import 'zx/globals';
 
 // Run the post-processing script for the documentation
 echo('Running post-processing script for the documentation...');

--- a/scripts/build-preprocess.js
+++ b/scripts/build-preprocess.js
@@ -1,4 +1,5 @@
-#!/usr/bin/env zx
+#!/usr/bin/env node
+import 'zx/globals';
 
 // Clean the docs/packages directory
 echo('Cleaning up docs/packages directory...');

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,4 +1,5 @@
-#!/usr/bin/env zx
+#!/usr/bin/env node
+import 'zx/globals';
 
 // Run pre-processing script for the build
 echo('Running pre-processing script for the build...');


### PR DESCRIPTION
This PR bumps Node from `v22` to `v24` and updates PNPM to the latest version. It also adds `zx/globals` imports to selected `scripts/` files.

### Key Changes

- **Bump versions:** Upgrades Node (`v22` → `v24`) and PNPM to latest.
- **CI:** Updates Node and PNPM dependencies.
- **Scripts:** Adds `zx/globals` imports to `scripts/build-postprocess.js`, `scripts/build-preprocess.js`, and `scripts/build.js` to improve TypeScript support. Updates interpreter shebang to `node`.