### PR TITLE
fix(yoot): relax `YootInput` type to accept generic objects; add internal utilities and tests

### DIFF
--- a/.changeset/bitter-pigs-look.md
+++ b/.changeset/bitter-pigs-look.md
@@ -1,0 +1,5 @@
+---
+'@yoot/yoot': patch
+---
+
+Relaxes `YootInput` type to accept generic object shapes (`Record<string, unknown>`).

--- a/docs/packages/yoot/yoot.yootinput.md
+++ b/docs/packages/yoot/yoot.yootinput.md
@@ -9,7 +9,7 @@ Input for `yoot()`<!-- -->: a source URL string or a partial `YootState` object.
 **Signature:**
 
 ```typescript
-type YootInput = string | Yoot | SomeYootState;
+type YootInput = string | SomeYootState | Yoot | Record<string, unknown>;
 ```
 
 **References:** [Yoot](./yoot.yoot.md)

--- a/packages/yoot/etc/yoot.api.md
+++ b/packages/yoot/etc/yoot.api.md
@@ -111,7 +111,7 @@ export function hasIntrinsicDimensions<
     width: number;
     height: number;
   },
-  Input extends Partial<Dimensions>,
+  Input extends Record<string, unknown>,
 >(input?: Input): input is Dimensions & Input;
 
 // @public
@@ -271,6 +271,12 @@ type SourceAttrsOptions = Prettify<Omit<SourceAttrs, 'height' | 'src' | 'width'>
 // @internal
 function toInlineStyle(props: unknown): string;
 
+// Warning: (ae-forgotten-export) The symbol "SomeYootState" needs to be exported by the entry point api-extractor.d.ts
+// Warning: (ae-internal-missing-underscore) The name "unwrapInput" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export function unwrapInput(input?: YootInput): SomeYootState;
+
 // @public
 export type Vertical = 'top' | 'bottom';
 
@@ -318,10 +324,8 @@ export interface YootFactory {
   (input?: YootInput): Yoot;
 }
 
-// Warning: (ae-forgotten-export) The symbol "SomeYootState" needs to be exported by the entry point api-extractor.d.ts
-//
 // @public
-export type YootInput = string | Yoot | SomeYootState;
+export type YootInput = string | SomeYootState | Yoot | Record<string, unknown>;
 
 // @public
 export type YootState = {

--- a/packages/yoot/src/core/utils.ts
+++ b/packages/yoot/src/core/utils.ts
@@ -1,6 +1,20 @@
 // -- Module Exports --
 export {hasIntrinsicDimensions, invariant};
-export {isKeyOf, isEmpty, isFunction, isNullish, isNumber, isString, isUrl};
+export {isKeyOf, isEmpty, isFunction, isNullish, isNumber, isPlainObject, isString, isUrl};
+
+/**
+ * Determines if a value is a plain object.
+ *
+ * @internal
+ * @param value - The value to check.
+ * @returns True if the value is a valid URL.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) return false;
+
+  const proto = Object.getPrototypeOf(value);
+  return proto === null || proto === Object.prototype;
+}
 
 /**
  * Determines if a value is a valid URL string.

--- a/packages/yoot/src/core/utils.ts
+++ b/packages/yoot/src/core/utils.ts
@@ -42,9 +42,10 @@ function isUrl(value: unknown): value is string {
  * @param input - The object to check, potentially having optional width and height.
  * @returns True if `input.width` and `input.height` are both valid numbers.
  */
-function hasIntrinsicDimensions<Dimensions extends {width: number; height: number}, Input extends Partial<Dimensions>>(
-  input?: Input,
-): input is Dimensions & Input {
+function hasIntrinsicDimensions<
+  Dimensions extends {width: number; height: number},
+  Input extends Record<string, unknown>,
+>(input?: Input): input is Dimensions & Input {
   if (!input) return false;
   return isNumber(input.width) && isNumber(input.height);
 }

--- a/packages/yoot/src/core/yoot.ts
+++ b/packages/yoot/src/core/yoot.ts
@@ -1,7 +1,7 @@
 import {_getAdapter as getAdapter} from './adapter.ts';
 import {mustBeOneOf, mustBeInRange, normalizeDirectives} from './helpers.ts';
 import {YOOT_BRAND} from './store.ts';
-import {invariant, isEmpty, isNullish, isNumber, isString, isUrl} from './utils.ts';
+import {invariant, isEmpty, isNullish, isNumber, isPlainObject, isString, isUrl} from './utils.ts';
 
 // -- Module Exports --
 // API function and helpers
@@ -155,8 +155,9 @@ function unwrapInput(input?: YootInput): SomeYootState {
     if (isUrl(input)) return {src: input};
 
     try {
-      // We may have a JSON string representing a state.
-      return JSON.parse(input);
+      // We may have a JSON string representing state.
+      const maybeState = JSON.parse(input);
+      return isPlainObject(maybeState) ? maybeState : {};
     } catch {
       return {};
     }
@@ -165,7 +166,7 @@ function unwrapInput(input?: YootInput): SomeYootState {
   // Is this a Yoot object?
   if (isYoot(input)) return input.toJSON();
 
-  return {...input};
+  return isPlainObject(input) ? {...input} : {};
 }
 
 /**

--- a/packages/yoot/src/core/yoot.ts
+++ b/packages/yoot/src/core/yoot.ts
@@ -6,6 +6,8 @@ import {invariant, isEmpty, isNullish, isNumber, isPlainObject, isString, isUrl}
 // -- Module Exports --
 // API function and helpers
 export {createYoot as yoot};
+// For testing
+export {unwrapInput};
 // Yoot related types
 export type {Yoot, YootFactory, YootInput, YootState, PrimeStateInput};
 // Directive related types
@@ -147,7 +149,7 @@ function yoot(state: YootState): Yoot {
 
 /**
  * Normalizes input into a `SomeYootState` object.
- * @remarks Accepts a URL string, JSON string, partial state, or a `Yoot` instance.
+ * @remarks Accepts a URL string, JSON string, partial state, or a `Yoot` object.
  * @internal
  */
 function unwrapInput(input?: YootInput): SomeYootState {

--- a/packages/yoot/src/core/yoot.ts
+++ b/packages/yoot/src/core/yoot.ts
@@ -271,7 +271,7 @@ type DirectiveHandler<K extends keyof Directives> = (value: NonNullable<Directiv
  * Input for `yoot()`: a source URL string or a partial `YootState` object.
  * @public
  */
-type YootInput = string | Yoot | SomeYootState;
+type YootInput = string | SomeYootState | Yoot | Record<string, unknown>;
 
 /**
  * The public Yoot API: a callable factory for new states, with chainable methods.

--- a/packages/yoot/tests/utils.test.ts
+++ b/packages/yoot/tests/utils.test.ts
@@ -2,12 +2,13 @@ import {describe, it, expect} from '@yoot/test-kit';
 
 import {
   hasIntrinsicDimensions,
+  invariant,
   isFunction,
   isNumber,
   isEmpty,
   isNullish,
   isKeyOf,
-  invariant,
+  isPlainObject,
   isString,
   isUrl,
 } from '../src/core/utils';
@@ -20,7 +21,6 @@ describe('utils', () => {
 
     it('returns false if input is undefined or has non-numeric dimensions', () => {
       expect(hasIntrinsicDimensions(undefined)).toBe(false);
-      // @ts-expect-error invalid type for test
       expect(hasIntrinsicDimensions({width: '100', height: 200})).toBe(false);
     });
   });
@@ -30,6 +30,58 @@ describe('utils', () => {
       expect(isFunction(() => {})).toBe(true);
       expect(isFunction('string')).toBe(false);
       expect(isFunction(123)).toBe(false);
+    });
+  });
+
+  describe('isPlainObject', () => {
+    it('returns true for a plain object literal', () => {
+      expect(isPlainObject({a: 1})).toBe(true);
+    });
+
+    it('returns true for an object with no prototype', () => {
+      const obj = Object.create(null);
+      expect(isPlainObject(obj)).toBe(true);
+    });
+
+    it('returns false for arrays', () => {
+      expect(isPlainObject([1, 2, 3])).toBe(false);
+    });
+
+    it('returns false for null', () => {
+      expect(isPlainObject(null)).toBe(false);
+    });
+
+    it('returns false for class instances', () => {
+      class Foo {
+        x = 1;
+      }
+      expect(isPlainObject(new Foo())).toBe(false);
+    });
+
+    it('returns false for functions', () => {
+      expect(isPlainObject(() => {})).toBe(false);
+    });
+
+    it('returns false for primitive types', () => {
+      expect(isPlainObject('hello')).toBe(false);
+      expect(isPlainObject(42)).toBe(false);
+      expect(isPlainObject(true)).toBe(false);
+      expect(isPlainObject(Symbol('x'))).toBe(false);
+      expect(isPlainObject(undefined)).toBe(false);
+    });
+
+    it('returns false for Date objects', () => {
+      expect(isPlainObject(new Date())).toBe(false);
+    });
+
+    it('returns false for RegExp objects', () => {
+      expect(isPlainObject(/abc/)).toBe(false);
+      expect(isPlainObject(new RegExp('abc'))).toBe(false);
+    });
+
+    it('returns false for Map and Set', () => {
+      expect(isPlainObject(new Map())).toBe(false);
+      expect(isPlainObject(new Set())).toBe(false);
     });
   });
 

--- a/packages/yoot/tests/yoot.test.ts
+++ b/packages/yoot/tests/yoot.test.ts
@@ -1,6 +1,7 @@
 import {beforeEach, describe, expect, it} from 'vitest';
 import {createTemplate} from '@yoot/test-kit';
 import type {GenerateUrlInput, YootFactory, YootInput} from '../src';
+import {unwrapInput} from '../src/core/yoot';
 
 const IMAGE_URL = 'https://foo.com/images/file.webp';
 const IMAGE_URL_WITH_DIRECTIVES = 'https://foo.com/images/file.webp?width=300&height=200&format=webp';
@@ -26,217 +27,246 @@ const normalizeUrl = (url: URL) => {
 
 let yoot: YootFactory;
 
-beforeEach(async () => {
-  const {defineAdapter, registerAdapters, ...exports} = await import('../src');
-  yoot = exports.yoot;
+describe('@yoot/yoot', () => {
+  describe('Core Functionality', () => {
+    beforeEach(async () => {
+      const {defineAdapter, registerAdapters, ...exports} = await import('../src');
+      yoot = exports.yoot;
 
-  const adapter = defineAdapter({
-    supports: (url: URL) => url.hostname === 'foo.com',
-    normalizeUrl,
-    generateUrl,
+      const adapter = defineAdapter({
+        supports: (url: URL) => url.hostname === 'foo.com',
+        normalizeUrl,
+        generateUrl,
+      });
+
+      registerAdapters(adapter);
+    });
+
+    describe('Initialization', () => {
+      it('should initialize with empty state if no input is provided', () => {
+        const api = yoot();
+        expect(api.toJSON()).toEqual({directives: {}});
+      });
+
+      it('should safely initialize with an invalid string input', () => {
+        const api = yoot('oops');
+        expect(api.toJSON()).toEqual({directives: {}});
+      });
+
+      it('should safely initialize with an invalid JSON string', () => {
+        const api = yoot('{oops}');
+        expect(api.toJSON()).toEqual({directives: {}});
+      });
+
+      it('should initialize state with just an image url', () => {
+        const api = yoot(IMAGE_URL);
+
+        expect(api.url).toBe(IMAGE_URL);
+        expect(api.toJSON().src).toBe(IMAGE_URL);
+      });
+
+      it('should initialize state with an input object', () => {
+        const input = {src: IMAGE_URL, alt: 'Test'};
+        const api = yoot(input);
+        const state = api.toJSON();
+
+        expect(state).toEqual({...input, directives: {}});
+      });
+
+      it('should initialize with a Yoot object', () => {
+        const ute = yoot(IMAGE_URL);
+        const ute2 = yoot(ute);
+
+        expect(ute.toJSON().src).toBe(IMAGE_URL);
+        expect(ute2.toJSON().src).toBe(IMAGE_URL);
+      });
+
+      it('should be immutable', () => {
+        const directives = {width: 100};
+        const api = yoot({src: IMAGE_URL, directives});
+
+        // Modify original objects (should not affect API state)
+        directives.width = 200;
+
+        const state = api.toJSON();
+
+        expect(state.directives).toEqual({width: 100});
+      });
+
+      it('should handle input object with undefined directives', () => {
+        const api = yoot({src: IMAGE_URL, directives: undefined});
+
+        const state = api.toJSON();
+
+        expect(state.src).toBe(IMAGE_URL);
+        expect(state.directives).toEqual({});
+      });
+    });
+
+    describe('API Methods and Chaining', () => {
+      it('should create immutable API objects on each method call', () => {
+        const base = yoot({src: IMAGE_URL});
+        const withWidth = base.width(100);
+        const withHeight = withWidth.height(200);
+
+        const baseState = base.toJSON();
+        const withWidthState = withWidth.toJSON();
+        const withHeightState = withHeight.toJSON();
+
+        expect(baseState.directives).toEqual({});
+        expect(withWidthState.directives).toEqual({width: 100});
+        expect(withHeightState.directives).toEqual({width: 100, height: 200});
+      });
+
+      it('should merge directives correctly with .map() method', () => {
+        const base = yoot({src: IMAGE_URL, directives: {width: 100, format: 'jpg'}});
+
+        const updated = base.map((state) => {
+          state.directives.quality = 80;
+          state.directives.format = 'webp';
+          return state;
+        });
+
+        expect(updated.toJSON().directives).toEqual({width: 100, format: 'webp', quality: 80});
+      });
+
+      it('should return a new API object with the same state', () => {
+        const base = yoot({src: IMAGE_URL, alt: 'Test'});
+        const next = base(); // Call with no arguments
+
+        expect(next).not.toBe(base);
+        expect(next.toJSON()).toEqual(base.toJSON());
+      });
+
+      it('should update src when invoking the API object directly with a URL string', () => {
+        const baseSrc = generateImageUrl();
+        const base = yoot({src: baseSrc});
+
+        const updatedSrc = generateImageUrl();
+        const updated = base(updatedSrc);
+
+        expect(base.toJSON().src).toBe(baseSrc);
+        expect(updated.toJSON().src).toBe(updatedSrc);
+      });
+    });
+
+    describe('State Merging', () => {
+      it('should merge directives with changes taking precedence', () => {
+        const base = yoot({
+          src: IMAGE_URL,
+          alt: 'Old Alt',
+          directives: {width: 100},
+        });
+
+        const next = base({alt: 'New Alt', directives: {height: 200}});
+        const nextState = next.toJSON();
+
+        expect(nextState.alt).toBe('New Alt');
+        expect(nextState.directives).toEqual({width: 100, height: 200});
+      });
+
+      it('should handle directives being initially undefined in current state', () => {
+        const base = yoot({src: IMAGE_URL});
+        const withDirectives = base({directives: {width: 100}});
+
+        expect(withDirectives.toJSON().directives).toEqual({width: 100});
+      });
+
+      it('should handle "directives" being undefined in changes', () => {
+        const base = yoot({src: IMAGE_URL, directives: {width: 100}});
+        const changed = base({directives: undefined});
+
+        expect(changed.toJSON().directives).toEqual({width: 100});
+      });
+    });
+
+    describe('Output Methods', () => {
+      it('should return a transformed URL', () => {
+        const ute = yoot(IMAGE_URL).width(300).height(200).format('webp');
+        expect(ute.url).toBe(`${IMAGE_URL}?width=300&height=200&format=webp`);
+      });
+
+      describe('baseUrl', () => {
+        it('should return a normalized URL', () => {
+          expect(yoot(IMAGE_URL_WITH_DIRECTIVES).baseUrl).toBe(IMAGE_URL);
+        });
+
+        it('should return null when a bad src URL is given', () => {
+          expect(yoot({src: 'oops'}).baseUrl).toBe(null);
+        });
+      });
+
+      describe('hasSrc', () => {
+        it('should return true when src is given', () => {
+          expect(yoot(IMAGE_URL).hasSrc).toBe(true);
+        });
+
+        it('should return false when src is empty', () => {
+          expect(yoot().hasSrc).toBe(false);
+        });
+      });
+
+      it('should successfully serialize and deserialize', () => {
+        const input: YootInput = {
+          src: IMAGE_URL,
+          alt: 'Test Alt',
+          width: 800,
+          height: 600,
+          directives: {format: 'webp', quality: 75},
+        };
+
+        const serialized = JSON.stringify(yoot(input));
+        const deserialized = JSON.parse(serialized);
+
+        expect(deserialized).toEqual({...input});
+      });
+
+      it('should serialize correctly when optional directives are nullish', () => {
+        const ute = yoot({src: IMAGE_URL, alt: 'Test', directives: undefined});
+        const serialized = JSON.stringify(ute);
+        const deserialized = JSON.parse(serialized);
+
+        expect(deserialized).toEqual({src: IMAGE_URL, alt: 'Test', directives: {}});
+      });
+    });
+
+    describe('Image src Handling and Errors', () => {
+      const tpl = createTemplate('should throw an error when calling %s with image src is not set');
+
+      it(tpl`.url`, () => {
+        expect(() => yoot().url).toThrowError();
+      });
+
+      it(tpl`.toString()`, () => {
+        expect(() => yoot().toString()).toThrowError();
+      });
+    });
   });
 
-  registerAdapters(adapter);
-});
-
-describe('@yoot/yoot - Core Functionality', () => {
-  describe('Initialization', () => {
-    it('should initialize with empty state if no input is provided', () => {
-      const api = yoot();
-      expect(api.toJSON()).toEqual({directives: {}});
-    });
-
-    it('should safely initialize with an invalid string input', () => {
-      const api = yoot('oops');
-      expect(api.toJSON()).toEqual({directives: {}});
-    });
-
-    it('should safely initialize with an invalid JSON string', () => {
-      const api = yoot('{oops}');
-      expect(api.toJSON()).toEqual({directives: {}});
-    });
-
-    it('should initialize state with just an image url', () => {
-      const api = yoot(IMAGE_URL);
-
-      expect(api.url).toBe(IMAGE_URL);
-      expect(api.toJSON().src).toBe(IMAGE_URL);
-    });
-
-    it('should initialize state with an input object', () => {
-      const input = {src: IMAGE_URL, alt: 'Test'};
-      const api = yoot(input);
-      const state = api.toJSON();
-
-      expect(state).toEqual({...input, directives: {}});
-    });
-
-    it('should initialize with a Yoot object', () => {
-      const ute = yoot(IMAGE_URL);
-      const ute2 = yoot(ute);
-
-      expect(ute.toJSON().src).toBe(IMAGE_URL);
-      expect(ute2.toJSON().src).toBe(IMAGE_URL);
-    });
-
-    it('should be immutable', () => {
-      const directives = {width: 100};
-      const api = yoot({src: IMAGE_URL, directives});
-
-      // Modify original objects (should not affect API state)
-      directives.width = 200;
-
-      const state = api.toJSON();
-
-      expect(state.directives).toEqual({width: 100});
-    });
-
-    it('should handle input object with undefined directives', () => {
-      const api = yoot({src: IMAGE_URL, directives: undefined});
-
-      const state = api.toJSON();
-
-      expect(state.src).toBe(IMAGE_URL);
-      expect(state.directives).toEqual({});
-    });
-  });
-
-  describe('API Methods and Chaining', () => {
-    it('should create immutable API objects on each method call', () => {
-      const base = yoot({src: IMAGE_URL});
-      const withWidth = base.width(100);
-      const withHeight = withWidth.height(200);
-
-      const baseState = base.toJSON();
-      const withWidthState = withWidth.toJSON();
-      const withHeightState = withHeight.toJSON();
-
-      expect(baseState.directives).toEqual({});
-      expect(withWidthState.directives).toEqual({width: 100});
-      expect(withHeightState.directives).toEqual({width: 100, height: 200});
-    });
-
-    it('should merge directives correctly with .map() method', () => {
-      const base = yoot({src: IMAGE_URL, directives: {width: 100, format: 'jpg'}});
-
-      const updated = base.map((state) => {
-        state.directives.quality = 80;
-        state.directives.format = 'webp';
-        return state;
+  describe('Internal Functions', () => {
+    describe('unwrapInput', () => {
+      it('should unwrap valid inputs', () => {
+        expect(unwrapInput({src: IMAGE_URL})).toEqual({src: IMAGE_URL});
+        expect(unwrapInput(JSON.stringify({src: IMAGE_URL}))).toEqual({src: IMAGE_URL});
       });
 
-      expect(updated.toJSON().directives).toEqual({width: 100, format: 'webp', quality: 80});
-    });
-
-    it('should return a new API object with the same state', () => {
-      const base = yoot({src: IMAGE_URL, alt: 'Test'});
-      const next = base(); // Call with no arguments
-
-      expect(next).not.toBe(base);
-      expect(next.toJSON()).toEqual(base.toJSON());
-    });
-
-    it('should update src when invoking the API object directly with a URL string', () => {
-      const baseSrc = generateImageUrl();
-      const base = yoot({src: baseSrc});
-
-      const updatedSrc = generateImageUrl();
-      const updated = base(updatedSrc);
-
-      expect(base.toJSON().src).toBe(baseSrc);
-      expect(updated.toJSON().src).toBe(updatedSrc);
-    });
-  });
-
-  describe('State Merging', () => {
-    it('should merge directives with changes taking precedence', () => {
-      const base = yoot({
-        src: IMAGE_URL,
-        alt: 'Old Alt',
-        directives: {width: 100},
+      it('should handle undefined or malformed input gracefully', () => {
+        expect(unwrapInput()).toEqual({});
+        expect(unwrapInput(undefined)).toEqual({});
+        // @ts-expect-error Intentionally passing invalid value
+        expect(unwrapInput(null)).toEqual({});
+        // @ts-expect-error Intentionally passing invalid value
+        expect(unwrapInput([])).toEqual({});
+        expect(unwrapInput({})).toEqual({});
       });
 
-      const next = base({alt: 'New Alt', directives: {height: 200}});
-      const nextState = next.toJSON();
-
-      expect(nextState.alt).toBe('New Alt');
-      expect(nextState.directives).toEqual({width: 100, height: 200});
-    });
-
-    it('should handle directives being initially undefined in current state', () => {
-      const base = yoot({src: IMAGE_URL});
-      const withDirectives = base({directives: {width: 100}});
-
-      expect(withDirectives.toJSON().directives).toEqual({width: 100});
-    });
-
-    it('should handle "directives" being undefined in changes', () => {
-      const base = yoot({src: IMAGE_URL, directives: {width: 100}});
-      const changed = base({directives: undefined});
-
-      expect(changed.toJSON().directives).toEqual({width: 100});
-    });
-  });
-
-  describe('Output Methods', () => {
-    it('should return a transformed URL', () => {
-      const ute = yoot(IMAGE_URL).width(300).height(200).format('webp');
-      expect(ute.url).toBe(`${IMAGE_URL}?width=300&height=200&format=webp`);
-    });
-
-    describe('baseUrl', () => {
-      it('should return a normalized URL', () => {
-        expect(yoot(IMAGE_URL_WITH_DIRECTIVES).baseUrl).toBe(IMAGE_URL);
+      it('should handle invalid string input safely', () => {
+        expect(unwrapInput('')).toEqual({});
+        expect(unwrapInput('{}')).toEqual({});
+        expect(unwrapInput('[]')).toEqual({});
+        expect(unwrapInput('null')).toEqual({});
+        expect(unwrapInput('undefined')).toEqual({});
       });
-
-      it('should return null when a bad src URL is given', () => {
-        expect(yoot({src: 'oops'}).baseUrl).toBe(null);
-      });
-    });
-
-    describe('hasSrc', () => {
-      it('should return true when src is given', () => {
-        expect(yoot(IMAGE_URL).hasSrc).toBe(true);
-      });
-
-      it('should return false when src is empty', () => {
-        expect(yoot().hasSrc).toBe(false);
-      });
-    });
-
-    it('should successfully serialize and deserialize', () => {
-      const input: YootInput = {
-        src: IMAGE_URL,
-        alt: 'Test Alt',
-        width: 800,
-        height: 600,
-        directives: {format: 'webp', quality: 75},
-      };
-
-      const serialized = JSON.stringify(yoot(input));
-      const deserialized = JSON.parse(serialized);
-
-      expect(deserialized).toEqual({...input});
-    });
-
-    it('should serialize correctly when optional directives are nullish', () => {
-      const ute = yoot({src: IMAGE_URL, alt: 'Test', directives: undefined});
-      const serialized = JSON.stringify(ute);
-      const deserialized = JSON.parse(serialized);
-
-      expect(deserialized).toEqual({src: IMAGE_URL, alt: 'Test', directives: {}});
-    });
-  });
-
-  describe('Image src Handling and Errors', () => {
-    const tpl = createTemplate('should throw an error when calling %s with image src is not set');
-
-    it(tpl`.url`, () => {
-      expect(() => yoot().url).toThrowError();
-    });
-
-    it(tpl`.toString()`, () => {
-      expect(() => yoot().toString()).toThrowError();
     });
   });
 });


### PR DESCRIPTION
This PR improves the `YootInput` type to support generic plain objects, enabling more flexible input values. It also includes internal utility and testing enhancements.

### Key Changes

- **Types:** Relaxed the `YootInput` type to include `Record<string, unknown>`, allowing support for plain object inputs.
- **Utils:** Added internal `isPlainObject` utility. Exported `unwrapInput` to enable unit testing.
- **Tests:** Added unit tests for `unwrapInput` and `isPlainObject`. Includes minor refactoring for improved clarity.