### PR TITLE
fix(yoot): simplify and correct attribute helpers

### DIFF
--- a/.changeset/weak-dodos-change.md
+++ b/.changeset/weak-dodos-change.md
@@ -1,0 +1,5 @@
+---
+'@yoot/yoot': patch
+---
+
+Fixes `getImgAttrs` helper where the `sizes` attribute wasn't returned when the `srcSetBuilder` was provided.

--- a/packages/yoot/src/core/helpers.ts
+++ b/packages/yoot/src/core/helpers.ts
@@ -224,19 +224,8 @@ type Attrs = {
 function getImgAttrs(yoot: Yoot, options?: ImgAttrsOptions): ImgAttrs {
   const {alt: alternateAlt, sizes, srcSetBuilder, ...passThroughAttrs} = options ?? {};
   const {src, height, width, ...derivedAttrs} = getAttrs(yoot);
-  const alt = derivedAttrs.alt || alternateAlt;
-  const attrs: HTMLImageAttributes = {...passThroughAttrs};
-  const imgAttrs: ImgAttrs = {src};
-
-  // Apply non-nullish pass-through attributes
-  for (const [key, value] of Object.entries(attrs)) {
-    if (isNullish(value)) continue;
-    // TODO - Is there a better way to type this?
-    (imgAttrs as Record<string, unknown>)[key] = value;
-  }
-
-  // Apply `alt`
-  if (isString(alt)) imgAttrs.alt = alt;
+  const alt = derivedAttrs.alt || alternateAlt || ''; // Ensure `alt` is always a string, even if empty
+  const imgAttrs: ImgAttrs = {src, alt, ...passThroughAttrs};
 
   // -- Apply `srcset` and fallback to `src` if not defined --
   // Overrides `srcset` if given

--- a/packages/yoot/src/core/helpers.ts
+++ b/packages/yoot/src/core/helpers.ts
@@ -1,7 +1,7 @@
 import type {GenerateUrlInput} from './adapter.ts';
 import type {Directives, Yoot, YootState} from './yoot.ts';
 import type {HTMLImageAttributes, HTMLSourceAttributes, Maybe, Prettify} from './types.ts';
-import {isKeyOf, isFunction, hasIntrinsicDimensions, invariant, isNumber, isString, isNullish} from './utils.ts';
+import {isKeyOf, isFunction, hasIntrinsicDimensions, invariant, isNumber, isString} from './utils.ts';
 
 export {
   buildSrcSet,
@@ -309,19 +309,12 @@ function getSourceAttrs(yoot: Yoot, options?: SourceAttrsOptions): SourceAttrs {
 
   /** @see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/source */
   const {width, height, src} = getAttrs(yoot);
-  const sourceAttrs: SourceAttrs = {}; // Ignore `src` from the initial `sourceAttrs` object
-
-  // Apply non-nullish pass-through attributes
-  for (const [key, value] of Object.entries(passThroughAttrs)) {
-    if (isNullish(value)) continue;
-    // TODO - Is there a better way to type this?
-    (sourceAttrs as Record<string, unknown>)[key] = value;
-  }
+  const sourceAttrs: SourceAttrs = {...passThroughAttrs}; // Ignore `src` from the initial `sourceAttrs` object
 
   const formatIsAuto = () => yoot.toResolvedJSON().directives.format === 'auto';
 
   // Apply inferred `type` if not explicitly provided
-  const mimeType = passThroughAttrs.type || getMimeType(yoot);
+  const mimeType = sourceAttrs.type || getMimeType(yoot);
   // Only apply `type` if format is not 'auto'.
   // Some CDNs dynamically determine the format based on accepts header.
   if (mimeType && !formatIsAuto()) sourceAttrs.type = mimeType;

--- a/packages/yoot/src/core/helpers.ts
+++ b/packages/yoot/src/core/helpers.ts
@@ -241,7 +241,7 @@ function getImgAttrs(yoot: Yoot, options?: ImgAttrsOptions): ImgAttrs {
   // -- Apply `srcset` and fallback to `src` if not defined --
   // Overrides `srcset` if given
   if (isFunction(srcSetBuilder)) imgAttrs.srcset = srcSetBuilder(yoot);
-  if (isString(sizes) && isString(attrs.srcset)) imgAttrs.sizes = sizes;
+  if (isString(sizes) && isString(imgAttrs.srcset)) imgAttrs.sizes = sizes;
 
   const hasWidth = isNumber(width);
   const hasHeight = isNumber(height);

--- a/packages/yoot/tests/helpers.test.ts
+++ b/packages/yoot/tests/helpers.test.ts
@@ -189,13 +189,24 @@ describe('@yoot/yoot - Helpers', () => {
       expect(attrs.sizes).toBe('50vw');
     });
 
-    it('includes sizes only if srcset or srcSetBuilder given', () => {
-      const attrsWithSizes = jsx.getImgAttrs(ute, {
+    it('should return sizes only if srcset has been given or generated via srcSetBuilder', () => {
+      // `srcset` is provided
+      const attrsWithSrcset = jsx.getImgAttrs(ute, {
         srcset: jsx.buildSrcSet({widths: [300]}, ute),
         sizes: '50vw',
       });
-      expect(attrsWithSizes.sizes).toBe('50vw');
 
+      expect(attrsWithSrcset.sizes).toBe('50vw');
+
+      // `srcSetBuilder` is provided
+      const attrsWithSrcSetBuilder = jsx.getImgAttrs(ute, {
+        srcSetBuilder: jsx.defineSrcSetBuilder({widths: [300]}),
+        sizes: '50vw',
+      });
+
+      expect(attrsWithSrcSetBuilder.sizes).toBe('50vw');
+
+      // No `srcset` or `srcSetBuilder` provided
       const attrsWithoutSrcset = jsx.getImgAttrs(ute, {sizes: '100vw'});
       expect(attrsWithoutSrcset.sizes).toBeUndefined();
     });


### PR DESCRIPTION
This PR resolves an issue with the `getImgAttrs` helper and simplifies the implementation of `getImgAttrs` and `getSourceAttrs` helpers.

### Key Changes

- **Fix:** Corrects a bug where the `sizes` attribute was ignored in `getImgAttrs` when `srcSetBuilder` was provided.
- **Refactor:** Simplifies the internal attribute assembly logic in both `getImgAttrs` and `getSourceAttrs` by using the declarative spread syntax.