### PR TITLE
fix(docs): update Node/NPM install command for adapters

### DIFF
--- a/.changeset/quick-chicken-teach.md
+++ b/.changeset/quick-chicken-teach.md
@@ -1,0 +1,8 @@
+---
+'@yoot/cloudinary': patch
+'@yoot/shopify': patch
+'@yoot/sanity': patch
+'@yoot/imgix': patch
+---
+
+**Docs:** Corrected the `Node / NPM` installation instructions to explicitly include the `@yoot/yoot` peer dependency, ensuring proper module resolution in Node environments.

--- a/packages/adapters/cloudinary/README.md
+++ b/packages/adapters/cloudinary/README.md
@@ -33,10 +33,8 @@
 ### Node / NPM
 
 ```bash
-npm install @yoot/cloudinary
+npm install @yoot/cloudinary @yoot/yoot
 ```
-
-> The core library (`@yoot/yoot`) is automatically installed.
 
 ### Deno / JSR
 

--- a/packages/adapters/imgix/README.md
+++ b/packages/adapters/imgix/README.md
@@ -33,10 +33,8 @@
 ### Node / NPM
 
 ```bash
-npm install @yoot/imgix
+npm install @yoot/imgix @yoot/yoot
 ```
-
-> The core library (`@yoot/yoot`) is automatically installed.
 
 ### Deno / JSR
 

--- a/packages/adapters/sanity/README.md
+++ b/packages/adapters/sanity/README.md
@@ -33,10 +33,8 @@
 ### Node / NPM
 
 ```bash
-npm install @yoot/sanity
+npm install @yoot/sanity @yoot/yoot
 ```
-
-> The core library (`@yoot/yoot`) is automatically installed.
 
 ### Deno / JSR
 

--- a/packages/adapters/shopify/README.md
+++ b/packages/adapters/shopify/README.md
@@ -33,10 +33,8 @@
 ### Node / NPM
 
 ```bash
-npm install @yoot/shopify
+npm install @yoot/shopify @yoot/yoot
 ```
-
-> The core library (`@yoot/yoot`) is automatically installed.
 
 ### Deno / JSR
 


### PR DESCRIPTION
This PR updates the `Node / NPM` installation instructions for all adapter packages to include the core `@yoot/yoot` package.

This change is necessary to ensure module resolution for the core library in a Node environment, providing a smoother, error-free integration experience for developers.

**Affected Packages:**

- `@yoot/cloudinary`
- `@yoot/imgix`
- `@yoot/sanity`
- `@yoot/shopify`